### PR TITLE
Update tests associated with SSH restructuring

### DIFF
--- a/src/firewheel/tests/unit/cli/test_cli_utils.py
+++ b/src/firewheel/tests/unit/cli/test_cli_utils.py
@@ -1,13 +1,15 @@
 import io
 import os
-import shlex
-import socket
 import tempfile
 import unittest
-from unittest.mock import patch, mock_open
+from unittest.mock import patch
 
-from firewheel.cli import utils
-from firewheel.cli.utils import HelperNotFoundError
+from firewheel.cli.utils import (
+    HelperNotFoundError,
+    load_helper,
+    parse_to_helper,
+    process_helper_group,
+)
 from firewheel.cli.helper import Helper
 from firewheel.cli.helper_group import HelperGroup
 
@@ -68,7 +70,7 @@ class CliUtilsTestCase(unittest.TestCase):
             }
         }
 
-        ret = utils.parse_to_helper(index_name, helper_dict)
+        ret = parse_to_helper(index_name, helper_dict)
         self.assertEqual(ret[0], index_helper_obj)
 
     @patch("builtins.input", side_effect=["yes"])
@@ -117,7 +119,7 @@ class CliUtilsTestCase(unittest.TestCase):
         helper_dict = {index_name: helper_group}
 
         func_args = f"{index_name} invalid"
-        ret = utils.parse_to_helper(func_args, helper_dict)
+        ret = parse_to_helper(func_args, helper_dict)
         self.assertEqual(ret[0], index_helper_obj)
 
     @patch("builtins.input", side_effect=["no"])
@@ -167,7 +169,7 @@ class CliUtilsTestCase(unittest.TestCase):
 
         func_args = f"{index_name} invalid"
         with self.assertRaises(HelperNotFoundError):
-            utils.parse_to_helper(func_args, helper_dict)
+            parse_to_helper(func_args, helper_dict)
 
     @patch("builtins.input", side_effect=["yes"])
     def test_parse_to_helper_no_index_args(self, _mock_input):
@@ -200,7 +202,7 @@ class CliUtilsTestCase(unittest.TestCase):
         helper_dict = {index_name: helper_group}
         func_args = f"{index_name} invalid"
         with self.assertRaises(HelperNotFoundError):
-            utils.parse_to_helper(func_args, helper_dict)
+            parse_to_helper(func_args, helper_dict)
 
     def test_parse_to_helper_args(self):
         # Create a directory in the temp directory
@@ -228,7 +230,7 @@ class CliUtilsTestCase(unittest.TestCase):
         helper_dict = {helper_name: valid_helper}
         arg_list = ["arg1", "arg2"]
         func_args = f"{helper_name} {' '.join(arg_list)}"
-        obj, args = utils.parse_to_helper(func_args, helper_dict)
+        obj, args = parse_to_helper(func_args, helper_dict)
         self.assertEqual(obj, valid_helper)
         self.assertEqual(args, arg_list)
 
@@ -277,7 +279,7 @@ class CliUtilsTestCase(unittest.TestCase):
         }
 
         invalid_path = os.path.join(index_path, "invalid")
-        utils.process_helper_group(invalid_path, helper_dict)
+        process_helper_group(invalid_path, helper_dict)
         msg = "Helper path not found"
         self.assertIn(msg, mock_stdout.getvalue())
 
@@ -319,7 +321,7 @@ class CliUtilsTestCase(unittest.TestCase):
         index_helper_obj = Helper("index", index_path)
         helper_dict = {index_name: {"index": index_helper_obj}}
 
-        utils.load_helper(os.path.join(index_path, helper_name), helper_dict)
+        load_helper(os.path.join(index_path, helper_name), helper_dict)
         msg_1 = "Malformed section encountered"
         msg_2 = "Continuing without Helper"
         self.assertIn(msg_1, mock_stdout.getvalue())
@@ -353,431 +355,8 @@ class CliUtilsTestCase(unittest.TestCase):
         index_helper_obj = Helper("index", index_path)
         helper_dict = {index_name: {"index": index_helper_obj}}
 
-        utils.load_helper(os.path.join(index_path, helper_name), helper_dict)
+        load_helper(os.path.join(index_path, helper_name), helper_dict)
         msg_1 = "Unexpected error while parsing Helper"
         msg_2 = "Continuing without Helper"
         self.assertIn(msg_1, mock_stdout.getvalue())
         self.assertIn(msg_2, mock_stdout.getvalue())
-
-
-class CliUtilsSSHTestCase(unittest.TestCase):
-    def setUp(self):
-        self.author = "Unittest"
-        self.description = "Testing this case."
-
-        # Specify the local host (defined by `minimegaAPI.cluster_head_node`)
-        self.local_hostname = f"{socket.gethostname()}"
-        # SSH-specific case settings
-        self.ssh = utils.SSHManager()
-        self.remote_user = "test_user"
-        self.remote_host = "hostname.test"
-        self.remote_address = f"{self.remote_user}@{self.remote_host}"
-        self.vm_ip = "ABC.DEF.GHI.JKL"
-        self.ssh_default_options = [  # A flattened form of the options list
-            "-o",
-            "LogLevel=error",
-            "-o",
-            "UserKnownHostsFile=/dev/null",
-            "-o",
-            "StrictHostKeyChecking=no",
-            "-o",
-            f"ProxyCommand ssh -o BatchMode=yes {self.local_hostname} -W %h:%p",
-        ]
-
-    @patch("subprocess.run")
-    @patch("firewheel.cli.utils.SSHManager._get_remote_vm_ip")
-    def test_call_ssh(self, mock_ip_method, mock_subprocess):
-        # Mock the acquisition of a remote VM IP address
-        mock_ip_method.return_value = self.vm_ip
-        # Mock a successful SSH call
-        mock_subprocess.return_value.returncode = 0
-
-        # Test the call (no additional options or command specified)
-        result = self.ssh(self.remote_address)
-        self.assertIs(result, mock_subprocess.return_value)
-        # Check that the SSH command executed via subprocess was correct
-        mock_subprocess.assert_called_with(
-            [
-                "ssh",
-                *self.ssh_default_options,
-                f"{self.remote_user}@{self.vm_ip}",
-            ],
-            check=True,
-            capture_output=False,
-        )
-
-    @patch("subprocess.run")
-    @patch("firewheel.cli.utils.SSHManager._get_remote_vm_ip")
-    def test_call_ssh_default_user(self, mock_ip_method, mock_subprocess):
-        # Mock the acquisition of a remote VM IP address
-        mock_ip_method.return_value = self.vm_ip
-        # Mock a successful SSH call
-        mock_subprocess.return_value.returncode = 0
-
-        # Test the call (no additional options or command specified)
-        result = self.ssh(self.remote_host)
-        self.assertIs(result, mock_subprocess.return_value)
-        # Check that the SSH command executed via subprocess was correct
-        mock_subprocess.assert_called_with(
-            [
-                "ssh",
-                *self.ssh_default_options,
-                f"{self.vm_ip}",
-            ],
-            check=True,
-            capture_output=False,
-        )
-
-    @patch("subprocess.run")
-    @patch("firewheel.cli.utils.SSHManager._get_remote_vm_ip")
-    def test_call_ssh_with_options(self, mock_ip_method, mock_subprocess):
-        # Mock the acquisition of a remote VM IP address
-        mock_ip_method.return_value = self.vm_ip
-        # Mock a successful SSH call
-        mock_subprocess.return_value.returncode = 0
-
-        # Test the call (with additional options)
-        test_options = [("-L", "localhost:5000:localhost:5000")]
-        result = self.ssh(self.remote_address, options=test_options)
-        self.assertIs(result, mock_subprocess.return_value)
-        # Check that the SSH command executed via subprocess was correct
-        mock_subprocess.assert_called_with(
-            [
-                "ssh",
-                *self.ssh_default_options,
-                *test_options[0],
-                f"{self.remote_user}@{self.vm_ip}",
-            ],
-            check=True,
-            capture_output=False,
-        )
-
-    @patch("subprocess.run")
-    @patch("firewheel.cli.utils.SSHManager._get_remote_vm_ip")
-    def test_call_ssh_with_command(self, mock_ip_method, mock_subprocess):
-        # Mock the acquisition of a remote VM IP address
-        mock_ip_method.return_value = self.vm_ip
-        # Mock a successful SSH call
-        mock_subprocess.return_value.returncode = 0
-
-        # Test the call (with command specified)
-        test_command = "ls -la"
-        result = self.ssh(self.remote_address, command=test_command)
-        self.assertIs(result, mock_subprocess.return_value)
-        # Check that the SSH command executed via subprocess was correct
-        mock_subprocess.assert_called_with(
-            [
-                "ssh",
-                *self.ssh_default_options,
-                f"{self.remote_user}@{self.vm_ip}",
-                *shlex.split(test_command),
-            ],
-            check=True,
-            capture_output=False,
-        )
-
-
-class CliUtilsParallelSSHTestCase(unittest.TestCase):
-    def setUp(self):
-        self.author = "Unittest"
-        self.description = "Testing this case."
-
-        # Specify the local host (defined by `minimegaAPI.cluster_head_node`)
-        self.local_hostname = f"{socket.gethostname()}"
-        # PSSH-specific case settings
-        self.pssh = utils.ParallelSSHManager()
-        self.remote_user = "test_user"
-        self.remote_hosts = ["hostname0.test", "hostname1.test"]
-        self.remote_addresses = [
-            f"{self.remote_user}@{host}" for host in self.remote_hosts
-        ]
-        self.vm_ips = ["ABC.DEF.GHI.JKL", "MNO.PQR.STU.VWX"]
-        self.pssh_default_options = [  # A flattened form of the options list
-            "-O",
-            "LogLevel=error",
-            "-O",
-            "UserKnownHostsFile=/dev/null",
-            "-O",
-            "StrictHostKeyChecking=no",
-            "-O",
-            f"ProxyCommand ssh -o BatchMode=yes {self.local_hostname} -W %h:%p",
-        ]
-
-    @patch("subprocess.run")
-    @patch("firewheel.cli.utils.ParallelSSHManager._get_remote_vm_ip")
-    def test_call_pssh(self, mock_ip_method, mock_subprocess):
-        # Mock the acquisition of remote VM IP addresses
-        mock_ip_method.side_effect = self.vm_ips
-        # Mock a successful PSSH call
-        mock_subprocess.return_value.returncode = 0
-
-        # Test the call
-        test_command = "ls -la"
-        test_options = [("-H", " ".join(self.remote_addresses)), ("-p", "10")]
-        result = self.pssh(test_command, options=test_options)
-        self.assertIs(result, mock_subprocess.return_value)
-        # Check that the PSSH command executed via subprocess was correct
-        mock_subprocess.assert_called_with(
-            [
-                "parallel-ssh",
-                *self.pssh_default_options,
-                "-H",
-                f"{self.remote_user}@{self.vm_ips[0]} {self.remote_user}@{self.vm_ips[1]}",
-                "-p",
-                "10",
-                test_command,
-            ],
-            check=True,
-            capture_output=False,
-        )
-
-    @patch("subprocess.run")
-    @patch("firewheel.cli.utils.ParallelSSHManager._get_remote_vm_ip")
-    def test_call_pssh_multiple_options(self, mock_ip_method, mock_subprocess):
-        # Mock the acquisition of remote VM IP addresses
-        mock_ip_method.side_effect = self.vm_ips
-        # Mock a successful PSSH call
-        mock_subprocess.return_value.returncode = 0
-
-        # Test the call
-        test_command = "ls -la"
-        test_options = [("-H", address) for address in self.remote_addresses]
-        result = self.pssh(test_command, options=test_options)
-        self.assertIs(result, mock_subprocess.return_value)
-        # Check that the SSH command executed via subprocess was correct
-        mock_subprocess.assert_called_with(
-            [
-                "parallel-ssh",
-                *self.pssh_default_options,
-                "-H",
-                f"{self.remote_user}@{self.vm_ips[0]}",
-                "-H",
-                f"{self.remote_user}@{self.vm_ips[1]}",
-                test_command,
-            ],
-            check=True,
-            capture_output=False,
-        )
-
-    @patch("subprocess.run")
-    def test_call_pssh_host_file(self, mock_subprocess):
-        # Mock the acquisition of remote VM IP addresses
-        mocked_vm_dict = {
-            host: {"control_ip": ip} for host, ip in zip(self.remote_hosts, self.vm_ips)
-        }
-        # Mock a successful PSSH call
-        mock_subprocess.return_value.returncode = 0
-
-        mocked_open = mock_open(read_data="\n".join(self.remote_addresses))
-        with patch(
-            "firewheel.cli.utils.Path.open", mocked_open
-        ) as mock_open_method, patch(
-            "firewheel.cli.utils.minimegaAPI.mm_vms"
-        ) as mock_vm_method, patch(
-            "firewheel.cli.utils.Path.unlink"
-        ) as mock_unlink_method:
-            mock_write_method = mock_open_method.return_value.write
-            mock_vm_method.return_value = mocked_vm_dict
-            # Test the call (with a file of hosts provided)
-            test_command = "ls -la"
-            test_options = [("-h", "test_file.txt")]
-            result = self.pssh(test_command, options=test_options)
-            self.assertIs(result, mock_subprocess.return_value)
-            # Check that the SSH command executed via subprocess was correct
-            mock_subprocess.assert_called_with(
-                [
-                    "parallel-ssh",
-                    *self.pssh_default_options,
-                    "-h",
-                    "test_file.tmp",
-                    test_command,
-                ],
-                check=True,
-                capture_output=False,
-            )
-            mock_write_method.assert_called_once_with(
-                "\n".join(f"{self.remote_user}@{self.vm_ips[_]}" for _ in (0, 1))
-            )
-            mock_unlink_method.assert_called_once()
-
-    def test_call_pssh_no_hosts(self):
-        # Test the call with no hosts specified
-        with self.assertRaises(ValueError):
-            test_command = "ls -la"
-            test_options = [("-p", "10")]
-            self.pssh(test_command, options=test_options)
-
-
-class CliUtilsSCPTestCase(unittest.TestCase):
-    def setUp(self):
-        self.author = "Unittest"
-        self.description = "Testing this case."
-
-        # Specify the local host (defined by `minimegaAPI.cluster_head_node`)
-        self.local_hostname = f"{socket.gethostname()}"
-        # SCP-specific case settings
-        self.scp = utils.SCPManager()
-        self.remote_user = "test_user"
-        self.remote_host = "hostname.test"
-        self.remote_address = f"{self.remote_user}@{self.remote_host}"
-        self.vm_ip = "ABC.DEF.GHI.JKL"
-        self.scp_default_options = [  # A flattened form of the options list
-            "-o",
-            "LogLevel=error",
-            "-o",
-            "UserKnownHostsFile=/dev/null",
-            "-o",
-            "StrictHostKeyChecking=no",
-            "-o",
-            f"ProxyCommand ssh -o BatchMode=yes {self.local_hostname} -W %h:%p",
-            "-r",
-        ]
-
-    @patch("subprocess.run")
-    @patch("firewheel.cli.utils.SCPManager._get_remote_vm_ip")
-    def test_call_scp_push(self, mock_ip_method, mock_subprocess):
-        # Mock the acquisition of a remote VM IP address
-        mock_ip_method.return_value = self.vm_ip
-        # Mock a successful SSH call (raises `SystemExit` with exit code 0)
-        mock_subprocess.return_value.returncode = 0
-
-        # Test pushing a file (no additional options specified)
-        local_source = "/test/local/location/file.test"
-        remote_file = "/test/remote/location"
-        remote_target = f"{self.remote_address}:{remote_file}"
-        result = self.scp(remote_target, local_source)
-        self.assertIs(result, mock_subprocess.return_value)
-        # Check that the SCP command executed via subprocess was correct
-        mock_subprocess.assert_called_with(
-            [
-                "scp",
-                *self.scp_default_options,
-                local_source,
-                f"{self.remote_user}@{self.vm_ip}:{remote_file}",
-            ],
-            check=True,
-            capture_output=False,
-        )
-
-    @patch("subprocess.run")
-    @patch("firewheel.cli.utils.SCPManager._get_remote_vm_ip")
-    def test_call_scp_push_multiple(self, mock_ip_method, mock_subprocess):
-        # Mock the acquisition of a remote VM IP address
-        mock_ip_method.return_value = self.vm_ip
-        # Mock a successful SSH call (raises `SystemExit` with exit code 0)
-        mock_subprocess.return_value.returncode = 0
-
-        # Test pushing multiple files (no additional options specified)
-        local_sources = [
-            "/test/local/location/file1.test",
-            "/test/local/location/file2.test",
-        ]
-        remote_file = "/test/remote/location"
-        remote_target = f"{self.remote_address}:{remote_file}"
-        result = self.scp(remote_target, *local_sources)
-        self.assertIs(result, mock_subprocess.return_value)
-        # Check that the SCP command executed via subprocess was correct
-        mock_subprocess.assert_called_with(
-            [
-                "scp",
-                *self.scp_default_options,
-                *local_sources,
-                f"{self.remote_user}@{self.vm_ip}:{remote_file}",
-            ],
-            check=True,
-            capture_output=False,
-        )
-
-    @patch("subprocess.run")
-    @patch("firewheel.cli.utils.SCPManager._get_remote_vm_ip")
-    def test_call_scp_pull(self, mock_ip_method, mock_subprocess):
-        # Mock the acquisition of a remote VM IP address
-        mock_ip_method.return_value = self.vm_ip
-        # Mock a successful SSH call (raises `SystemExit` with exit code 0)
-        mock_subprocess.return_value.returncode = 0
-
-        # Test pulling a file (no additional options specified)
-        local_target = "/test/local/location/"
-        remote_file = "/test/remote/location/file.test"
-        remote_source = f"{self.remote_address}:{remote_file}"
-        result = self.scp(local_target, remote_source)
-        self.assertIs(result, mock_subprocess.return_value)
-        # Check that the SCP command executed via subprocess was correct
-        mock_subprocess.assert_called_with(
-            [
-                "scp",
-                *self.scp_default_options,
-                f"{self.remote_user}@{self.vm_ip}:{remote_file}",
-                local_target,
-            ],
-            check=True,
-            capture_output=False,
-        )
-
-    @patch("subprocess.run")
-    @patch("firewheel.cli.utils.SCPManager._get_remote_vm_ip")
-    def test_call_scp_pull_multiple(self, mock_ip_method, mock_subprocess):
-        # Mock the acquisition of a remote VM IP address
-        mock_ip_method.return_value = self.vm_ip
-        # Mock a successful SSH call (raises `SystemExit` with exit code 0)
-        mock_subprocess.return_value.returncode = 0
-
-        # Test pulling multiple files (no additional options specified)
-        local_target = "/test/local/location/"
-        remote_files = [
-            "/test/remote/location/file1.test",
-            "/test/remote/location/file2.test",
-        ]
-        remote_sources = [f"{self.remote_user}@{self.vm_ip}:{_}" for _ in remote_files]
-        result = self.scp(local_target, *remote_sources)
-        self.assertIs(result, mock_subprocess.return_value)
-        # Check that the SCP command executed via subprocess was correct
-        mock_subprocess.assert_called_with(
-            [
-                "scp",
-                *self.scp_default_options,
-                *remote_sources,
-                local_target,
-            ],
-            check=True,
-            capture_output=False,
-        )
-
-    def test_scp_invalid_no_source_files(self):
-        # Test the call with no source files specified
-        with self.assertRaises(ValueError):
-            self.scp("test_target")
-
-    def test_scp_invalid_no_remote(self):
-        # Test the call with no remote system specified
-        with self.assertRaises(SystemExit) as context:
-            self.scp("test_target", "test_source")
-            self.assertEqual(context.exception.code, 1)
-
-    @patch("subprocess.run")
-    @patch("firewheel.cli.utils.SCPManager._get_remote_vm_ip")
-    def test_scp_pull_with_options(self, mock_ip_method, mock_subprocess):
-        # Mock the acquisition of a remote VM IP address
-        mock_ip_method.return_value = self.vm_ip
-        # Mock a successful SSH call (raises `SystemExit` with exit code 0)
-        mock_subprocess.return_value.returncode = 0
-
-        # Test pulling a file (with additional options)
-        local_target = "/test/local/location/"
-        remote_file = "/test/remote/location/file.test"
-        remote_source = f"{self.remote_address}:{remote_file}"
-        test_options = [("-f", "alt_ssh_config")]
-        result = self.scp(local_target, remote_source, options=test_options)
-        self.assertIs(result, mock_subprocess.return_value)
-        # Check that the SCP command executed via subprocess was correct
-        mock_subprocess.assert_called_with(
-            [
-                "scp",
-                *self.scp_default_options,
-                *test_options[0],
-                f"{self.remote_user}@{self.vm_ip}:{remote_file}",
-                local_target,
-            ],
-            check=True,
-            capture_output=False,
-        )

--- a/src/firewheel/tests/unit/cli/test_ssh_manager.py
+++ b/src/firewheel/tests/unit/cli/test_ssh_manager.py
@@ -1,0 +1,378 @@
+import shlex
+import socket
+from unittest.mock import patch, mock_open
+
+import pytest
+
+from firewheel.cli.ssh_manager import SSHManager, ParallelSSHManager, SCPManager
+
+
+class _TestSSHProtocolManager:
+
+    # Specify the local host (defined by `minimegaAPI.cluster_head_node`)
+    local_hostname = f"{socket.gethostname()}"
+    # Create a flattened form of the options common among SSH protocols
+    default_options = [
+        "-o",
+        "LogLevel=error",
+        "-o",
+        "UserKnownHostsFile=/dev/null",
+        "-o",
+        "StrictHostKeyChecking=no",
+        "-o",
+        "HostKeyAlgorithms=+ssh-rsa",
+        "-o",
+        f"ProxyCommand ssh -o BatchMode=yes {local_hostname} -W %h:%p",
+    ]
+
+
+@pytest.fixture
+def ssh():
+    ssh = SSHManager()
+    # Mock the acquisition of a remote VM IP address
+    with patch.object(ssh, "_get_remote_vm_ip", return_value=TestSSHManager.vm_ip):
+        yield ssh
+
+
+class TestSSHManager(_TestSSHProtocolManager):
+
+    # SSH-specific case settings
+    user = "test_user"
+    host = "hostname.test"
+    vm_ip = "ABC.DEF.GHI.JKL"
+    host_based_address = f"{user}@{host}"
+    ip_based_address = f"{user}@{vm_ip}"
+
+    @patch("subprocess.run")
+    def test_call_ssh(self, mock_subprocess, ssh):
+        # Mock a successful SSH call
+        mock_subprocess.return_value.returncode = 0
+
+        # Test the call (no additional options or command specified)
+        result = ssh(self.host_based_address)
+        assert result is mock_subprocess.return_value
+        # Check that the SSH command executed via subprocess was correct
+        mock_subprocess.assert_called_with(
+            ["ssh", *self.default_options, self.ip_based_address],
+            check=True,
+            capture_output=False,
+        )
+
+    @patch("subprocess.run")
+    def test_call_ssh_default_user(self, mock_subprocess, ssh):
+        # Mock a successful SSH call
+        mock_subprocess.return_value.returncode = 0
+
+        # Test the call (no additional options or command specified)
+        result = ssh(self.host)
+        assert result is mock_subprocess.return_value
+        # Check that the SSH command executed via subprocess was correct
+        mock_subprocess.assert_called_with(
+            ["ssh", *self.default_options, f"{self.vm_ip}"],
+            check=True,
+            capture_output=False,
+        )
+
+    @patch("subprocess.run")
+    def test_call_ssh_with_options(self, mock_subprocess, ssh):
+        # Mock a successful SSH call
+        mock_subprocess.return_value.returncode = 0
+
+        # Test the call (with additional options)
+        options = [("-L", "localhost:5000:localhost:5000")]
+        result = ssh(self.host_based_address, options=options)
+        assert result is mock_subprocess.return_value
+        # Check that the SSH command executed via subprocess was correct
+        mock_subprocess.assert_called_with(
+            ["ssh", *self.default_options, *options[0], self.ip_based_address],
+            check=True,
+            capture_output=False,
+        )
+
+    @patch("subprocess.run")
+    def test_call_ssh_with_command(self, mock_subprocess, ssh):
+        # Mock a successful SSH call
+        mock_subprocess.return_value.returncode = 0
+
+        # Test the call (with command specified)
+        command = "ls -la"
+        result = ssh(self.host_based_address, command=command)
+        assert result is mock_subprocess.return_value
+        # Check that the SSH command executed via subprocess was correct
+        mock_subprocess.assert_called_with(
+            [
+                "ssh",
+                *self.default_options,
+                self.ip_based_address,
+                *shlex.split(command),
+            ],
+            check=True,
+            capture_output=False,
+        )
+
+
+@pytest.fixture
+def pssh():
+    pssh = ParallelSSHManager()
+    # Mock the acquisition of a remote VM IP address
+    with patch.object(pssh, "_get_remote_vm_ip", side_effect=TestPSSHManager.vm_ips):
+        yield pssh
+
+
+class TestPSSHManager(_TestSSHProtocolManager):
+
+    # PSSH-specific case settings
+    user = "test_user"
+    hosts = ["hostname0.test", "hostname1.test"]
+    vm_ips = ["ABC.DEF.GHI.JKL", "MNO.PQR.STU.VWX"]
+    host_based_addresses = [f"{user}@{hosts[0]}", f"{user}@{hosts[1]}"]
+    ip_based_addresses = [f"{user}@{vm_ips[0]}", f"{user}@{vm_ips[1]}"]
+
+    @property
+    def default_options(self):
+        # SSH options passed by parallel-ssh use a "-O" instead of "-o"
+        return ["-O" if arg == "-o" else arg for arg in super().default_options]
+
+    @patch("subprocess.run")
+    def test_call_pssh(self, mock_subprocess, pssh):
+        # Mock a successful PSSH call
+        mock_subprocess.return_value.returncode = 0
+
+        # Test the call
+        command = "ls -la"
+        options = [
+            ("-H", " ".join(self.host_based_addresses)),
+            ("-p", "10"),
+        ]
+        result = pssh(command, options=options)
+        assert result is mock_subprocess.return_value
+        # Check that the PSSH command executed via subprocess was correct
+        mock_subprocess.assert_called_with(
+            [
+                "parallel-ssh",
+                *self.default_options,
+                "-H",
+                f"{self.ip_based_addresses[0]} {self.ip_based_addresses[1]}",
+                "-p",
+                "10",
+                command,
+            ],
+            check=True,
+            capture_output=False,
+        )
+
+    @patch("subprocess.run")
+    def test_call_pssh_multiple_options(self, mock_subprocess, pssh):
+        # Mock a successful PSSH call
+        mock_subprocess.return_value.returncode = 0
+
+        # Test the call
+        command = "ls -la"
+        options = [("-H", address) for address in self.host_based_addresses]
+        result = pssh(command, options=options)
+        assert result is mock_subprocess.return_value
+        # Check that the SSH command executed via subprocess was correct
+        mock_subprocess.assert_called_with(
+            [
+                "parallel-ssh",
+                *self.default_options,
+                "-H",
+                f"{self.ip_based_addresses[0]}",
+                "-H",
+                f"{self.ip_based_addresses[1]}",
+                command,
+            ],
+            check=True,
+            capture_output=False,
+        )
+
+    @patch("subprocess.run")
+    def test_call_pssh_host_file(self, mock_subprocess, pssh):
+        # Mock the acquisition of remote VM IP addresses
+        mocked_vm_dict = {
+            host: {"control_ip": ip} for host, ip in zip(self.hosts, self.vm_ips)
+        }
+        # Mock a successful PSSH call
+        mock_subprocess.return_value.returncode = 0
+
+        mocked_open = mock_open(read_data="\n".join(self.host_based_addresses))
+        with patch(
+            "firewheel.cli.ssh_manager.Path.open", mocked_open
+        ) as mock_open_method, patch(
+            "firewheel.cli.ssh_manager.minimegaAPI.mm_vms"
+        ) as mock_vm_method, patch(
+            "firewheel.cli.ssh_manager.Path.unlink"
+        ) as mock_unlink_method:
+            mock_write_method = mock_open_method.return_value.write
+            mock_vm_method.return_value = mocked_vm_dict
+            # Test the call (with a file of hosts provided)
+            command = "ls -la"
+            options = [("-h", "test_file.txt")]
+            result = pssh(command, options=options)
+            assert result is mock_subprocess.return_value
+            # Check that the SSH command executed via subprocess was correct
+            mock_subprocess.assert_called_with(
+                ["parallel-ssh", *self.default_options, "-h", "test_file.tmp", command],
+                check=True,
+                capture_output=False,
+            )
+            mock_write_method.assert_called_once_with(
+                "\n".join(self.ip_based_addresses)
+            )
+            mock_unlink_method.assert_called_once()
+
+    def test_call_pssh_no_hosts(self, pssh):
+        # Test the call with no hosts specified
+        with pytest.raises(ValueError):
+            pssh("ls -la", options=[("-p", "10")])
+
+
+@pytest.fixture
+def scp():
+    scp = SCPManager()
+    # Mock the acquisition of a remote VM IP address
+    with patch.object(scp, "_get_remote_vm_ip", return_value=TestSCPManager.vm_ip):
+        yield scp
+
+
+class TestSCPManager(_TestSSHProtocolManager):
+
+    # SCP-specific case settings
+    user = "test_user"
+    host = "hostname.test"
+    vm_ip = "ABC.DEF.GHI.JKL"
+    host_based_address = f"{user}@{host}"
+    ip_based_address = f"{user}@{vm_ip}"
+
+    @property
+    def default_options(self):
+        return [*super().default_options, "-r"]
+
+    @patch("subprocess.run")
+    def test_call_scp_push(self, mock_subprocess, scp):
+        # Mock a successful SSH call (raises `SystemExit` with exit code 0)
+        mock_subprocess.return_value.returncode = 0
+
+        # Test pushing a file (no additional options specified)
+        local_source = "/test/local/location/file.test"
+        remote_file = "/test/remote/location"
+        remote_target = f"{self.host_based_address}:{remote_file}"
+        result = scp(remote_target, local_source)
+        assert result is mock_subprocess.return_value
+        # Check that the SCP command executed via subprocess was correct
+        mock_subprocess.assert_called_with(
+            [
+                "scp",
+                *self.default_options,
+                local_source,
+                f"{self.ip_based_address}:{remote_file}",
+            ],
+            check=True,
+            capture_output=False,
+        )
+
+    @patch("subprocess.run")
+    def test_call_scp_push_multiple(self, mock_subprocess, scp):
+        # Mock a successful SSH call (raises `SystemExit` with exit code 0)
+        mock_subprocess.return_value.returncode = 0
+
+        # Test pushing multiple files (no additional options specified)
+        local_sources = [
+            "/test/local/location/file1.test",
+            "/test/local/location/file2.test",
+        ]
+        remote_file = "/test/remote/location"
+        remote_target = f"{self.host_based_address}:{remote_file}"
+        result = scp(remote_target, *local_sources)
+        assert result is mock_subprocess.return_value
+        # Check that the SCP command executed via subprocess was correct
+        mock_subprocess.assert_called_with(
+            [
+                "scp",
+                *self.default_options,
+                *local_sources,
+                f"{self.ip_based_address}:{remote_file}",
+            ],
+            check=True,
+            capture_output=False,
+        )
+
+    @patch("subprocess.run")
+    def test_call_scp_pull(self, mock_subprocess, scp):
+        # Mock a successful SSH call (raises `SystemExit` with exit code 0)
+        mock_subprocess.return_value.returncode = 0
+
+        # Test pulling a file (no additional options specified)
+        local_target = "/test/local/location/"
+        remote_file = "/test/remote/location/file.test"
+        remote_source = f"{self.host_based_address}:{remote_file}"
+        result = scp(local_target, remote_source)
+        assert result is mock_subprocess.return_value
+        # Check that the SCP command executed via subprocess was correct
+        mock_subprocess.assert_called_with(
+            [
+                "scp",
+                *self.default_options,
+                f"{self.ip_based_address}:{remote_file}",
+                local_target,
+            ],
+            check=True,
+            capture_output=False,
+        )
+
+    @patch("subprocess.run")
+    def test_call_scp_pull_multiple(self, mock_subprocess, scp):
+        # Mock a successful SSH call (raises `SystemExit` with exit code 0)
+        mock_subprocess.return_value.returncode = 0
+
+        # Test pulling multiple files (no additional options specified)
+        local_target = "/test/local/location/"
+        remote_files = [
+            "/test/remote/location/file1.test",
+            "/test/remote/location/file2.test",
+        ]
+        remote_sources = [f"{self.ip_based_address}:{_}" for _ in remote_files]
+        result = scp(local_target, *remote_sources)
+        assert result is mock_subprocess.return_value
+        # Check that the SCP command executed via subprocess was correct
+        mock_subprocess.assert_called_with(
+            ["scp", *self.default_options, *remote_sources, local_target],
+            check=True,
+            capture_output=False,
+        )
+
+    def test_scp_invalid_no_source_files(self, scp):
+        # Test the call with no source files specified
+        with pytest.raises(ValueError):
+            scp("test_target")
+
+    def test_scp_invalid_no_remote(self, scp):
+        # Test the call with no remote system specified
+        with pytest.raises(SystemExit) as context:
+            scp("test_target", "test_source")
+            assert context.exception.code == 1
+
+    @patch("subprocess.run")
+    def test_scp_pull_with_options(self, mock_subprocess, scp):
+        # Mock a successful SSH call (raises `SystemExit` with exit code 0)
+        mock_subprocess.return_value.returncode = 0
+
+        # Test pulling a file (with additional options)
+        local_target = "/test/local/location/"
+        remote_file = "/test/remote/location/file.test"
+        remote_source = f"{self.host_based_address}:{remote_file}"
+        options = [("-f", "alt_ssh_config")]
+        result = scp(local_target, remote_source, options=options)
+        assert result is mock_subprocess.return_value
+        # Check that the SCP command executed via subprocess was correct
+        mock_subprocess.assert_called_with(
+            [
+                "scp",
+                *self.default_options,
+                *options[0],
+                f"{self.ip_based_address}:{remote_file}",
+                local_target,
+            ],
+            check=True,
+            capture_output=False,
+        )


### PR DESCRIPTION
Updates the unit testing associated with the SSH protocol managers (see sandialabs/firewheel#49).

For passing tests, see [this pipeline](https://github.com/mitchnegus/firewheel/actions/runs/12999922302).