### PR TITLE
Ansible playbooks

### DIFF
--- a/src/firewheel/control/ansible_playbooks/main.yml
+++ b/src/firewheel/control/ansible_playbooks/main.yml
@@ -70,6 +70,19 @@
         msg: "All cache file methods have failed and system does not appear to be online. Please provide valid cache information."
       when: (ping_result.rc | default(0)) != 0
 
+    # Process each package in INSTALL/pkgs
+    - name: Find package files in INSTALL/pkgs
+      ansible.builtin.find:
+        paths: "{{ pkgs_dir }}"
+        patterns: "*.yml"
+      register: pkg_files
+
+    - name: Process each package
+      ansible.builtin.include_tasks: roles/firewheel/tasks/pkgs_tasks.yml
+      vars:
+        pkg_file: "{{ item.path }}"
+      loop: "{{ pkg_files.files }}"
+
     # If we don't have any cached files and are online
     # then we need to run the MC Install tasks
     - name: "Include tasks (if needed) for: {{ mc_name }}"

--- a/src/firewheel/control/ansible_playbooks/main.yml
+++ b/src/firewheel/control/ansible_playbooks/main.yml
@@ -71,17 +71,25 @@
       when: (ping_result.rc | default(0)) != 0
 
     # Process each package in INSTALL/pkgs
+    - name: Check if pkgs_dir exists
+      ansible.builtin.stat:
+        path: "{{ mc_dir }}/INSTALL/pkgs"
+      register: pkgs_dir_status
+      failed_when: false
+
     - name: Find package files in INSTALL/pkgs
       ansible.builtin.find:
-        paths: "{{ pkgs_dir }}"
+        paths: "{{ mc_dir }}/INSTALL/pkgs"
         patterns: "*.yml"
       register: pkg_files
+      when: pkgs_dir_status.stat.exists
 
     - name: Process each package
       ansible.builtin.include_tasks: roles/firewheel/tasks/pkgs_tasks.yml
       vars:
         pkg_file: "{{ item.path }}"
       loop: "{{ pkg_files.files }}"
+      when: pkg_files.files is defined and pkg_files.files|length > 0
 
     # If we don't have any cached files and are online
     # then we need to run the MC Install tasks

--- a/src/firewheel/control/ansible_playbooks/roles/firewheel/tasks/pkgs_tasks.yml
+++ b/src/firewheel/control/ansible_playbooks/roles/firewheel/tasks/pkgs_tasks.yml
@@ -1,0 +1,69 @@
+---
+###################################################################################################
+# Tasks File: pkgs_tasks.yml
+# Description:
+#   **This is not a replacement for `required_files`. This replaces a common download pattern for 
+#   external packages and packages included here should be entered into required_files separately.**
+#   This Ansible tasks file is designed to process individual packages defined in the `INSTALL/pkgs`
+#   directory. Each package is represented as a `.yml` file containing metadata about the package,
+#   including its name, target tarball, target subdirectory, and the files it requires.
+#
+#   The tasks perform the following steps:
+#   1. Load package variables from the `.yml` file.
+#   2. Create the target subdirectory if it does not exist.
+#   3. Download and verify files for the package using `ansible.builtin.get_url`.
+#   4. Compress the package directory into a `.tgz` tarball.
+#   5. Remove the package directory after compression.
+#
+# Package `.yml` File Structure:
+#   Each package `.yml` file should follow this structure:
+#   ---
+#   name: "<package_name>"
+#   target_subdir: "<target_subdirectory>"  # Optional; defaults to "vm_resources"
+#   target: "<tarball_name>.tgz"
+#   files:
+#     - dest: "<destination_path>"
+#       url: "<file_url>"
+#       sha256: "<checksum>"
+#
+# Example:
+#   ---
+#   name: "htop"
+#   target_subdir: "vm_resources/debs"
+#   target: "htop-1_0_2_debs.tgz"
+#   files:
+#     - dest: "htop_1.0.2-3_amd64.deb"
+#       url: "http://archive.ubuntu.com/ubuntu/pool/universe/h/htop/htop_1.0.2-3_amd64.deb"
+#       sha256: "0311d8a26689935ca53e8e9252cb2d95a1fdc2f8278f4edb5733f555dad984a9"
+###################################################################################################
+
+- name: Load package variables
+  ansible.builtin.include_vars:
+    file: "{{ pkg_file }}"
+
+- name: Set default target_subdir if not specified
+  ansible.builtin.set_fact:
+    target_subdir: "{{ target_subdir | default('vm_resources') }}"
+
+- name: Create target subdirectory
+  ansible.builtin.file:
+    path: "{{ mc_dir }}/{{ target_subdir }}"
+    state: directory
+
+- name: Download and verify files for package: {{ name }}
+  ansible.builtin.get_url:
+    url: "{{ item.url }}"
+    dest: "{{ mc_dir }}/{{ target_subdir }}/{{ name }}/{{ item.dest }}"
+    checksum: "sha256:{{ item.sha256 }}"
+  loop: "{{ files }}"
+
+- name: Compress package directory into tarball
+  ansible.builtin.archive:
+    path: "{{ mc_dir }}/{{ target_subdir }}/{{ name }}"
+    dest: "{{ mc_dir }}/{{ target_subdir }}/{{ target }}"
+    format: gz
+
+- name: Remove package directory
+  ansible.builtin.file:
+    path: "{{ mc_dir }}/{{ target_subdir }}/{{ name }}"
+    state: absent

--- a/src/firewheel/control/ansible_playbooks/roles/firewheel/tasks/pkgs_tasks.yml
+++ b/src/firewheel/control/ansible_playbooks/roles/firewheel/tasks/pkgs_tasks.yml
@@ -2,7 +2,7 @@
 ###################################################################################################
 # Tasks File: pkgs_tasks.yml
 # Description:
-#   **This is not a replacement for `required_files`. This replaces a common download pattern for 
+#   **This is not a replacement for `required_files`. This replaces a common download pattern for
 #   external packages and packages included here should be entered into required_files separately.**
 #   This Ansible tasks file is designed to process individual packages defined in the `INSTALL/pkgs`
 #   directory. Each package is represented as a `.yml` file containing metadata about the package,
@@ -40,6 +40,7 @@
 - name: Load package variables
   ansible.builtin.include_vars:
     file: "{{ pkg_file }}"
+  failed_when: pkg_file is not defined or pkg_file|length == 0
 
 - name: Set default target_subdir if not specified
   ansible.builtin.set_fact:
@@ -47,23 +48,27 @@
 
 - name: Create target subdirectory
   ansible.builtin.file:
-    path: "{{ mc_dir }}/{{ target_subdir }}"
+    path: "{{ mc_dir }}/{{ target_subdir }}/{{ name }}"
     state: directory
 
-- name: Download and verify files for package: {{ name }}
+- name: "Download and verify files for package: {{ name }}"
   ansible.builtin.get_url:
     url: "{{ item.url }}"
     dest: "{{ mc_dir }}/{{ target_subdir }}/{{ name }}/{{ item.dest }}"
     checksum: "sha256:{{ item.sha256 }}"
   loop: "{{ files }}"
+  when: files is defined and files|length > 0
+  failed_when: item.url is not defined or item.sha256 is not defined
 
 - name: Compress package directory into tarball
   ansible.builtin.archive:
     path: "{{ mc_dir }}/{{ target_subdir }}/{{ name }}"
     dest: "{{ mc_dir }}/{{ target_subdir }}/{{ target }}"
     format: gz
+  when: target is defined and target|length > 0
 
 - name: Remove package directory
   ansible.builtin.file:
     path: "{{ mc_dir }}/{{ target_subdir }}/{{ name }}"
     state: absent
+  when: target_subdir is defined and name is defined and name|length > 0


### PR DESCRIPTION
### Current State
---

Currently, some Model Components may require additional data to be downloaded (e.g., VM resources, external packages, etc.) that cannot or should not be stored within the MC repository package. In this case, Model Components can have an INSTALL directory, which contains an Ansible playbook or an executable script (as denoted by a [shebang](https://en.wikipedia.org/wiki/Shebang_(Unix)) line). See: [Model Component INSTALL file](https://sandialabs.github.io/firewheel/model_component/mc_install.html#mc-install).

This PR introduces the **pkgs integration**, enabling Model Components to define external packages in a structured way using metadata files within the **`INSTALL/pkgs`** directory for consistency in downloading resources. These packages are processed during installation using Ansible tasks, replacing redundant logic in `tasks.yml`.

---

### Primary Benefits
---

There are several primary motivators for this change:
- [Idempotence](https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_intro.html#id6) - By design, Ansible playbooks are significantly easier to run multiple times without changing the final state. This is necessary when installation fails and needs to be re-run. While other scripts can have this property, Ansible makes it significantly easier to achieve.
- Readability - Package processing logic is now centralized in **`pkgs_tasks.yml`**, making it easier to read, maintain, and debug compared to shell-based scripts.
- Offline Accessibility - Packages defined in **`INSTALL/pkgs`** can be cached and retrieved from various sources (e.g., Git, S3, file servers), enabling offline installations.
- Reproducibility - Packages are defined with exact versions and checksums, ensuring consistent experimental outcomes.
- Cleanup - Intermediate files and directories created during package processing are automatically cleaned up, leaving only the essential artifacts.

---

### Key Changes
---

- **`pkgs_tasks.yml`**: Added a centralized Ansible tasks file to handle package processing, including downloading, verifying, compressing, and cleaning up package directories.
- **`INSTALL/pkgs` Directory**: Introduced an optional directory for defining package metadata files. Each `.yml` file specifies the package name, target tarball, target subdirectory, and files to download.
- **Simplified `tasks.yml`**: Updated `tasks.yml` to delegate package processing to `pkgs_tasks.yml`, reducing redundancy.
- **Updated Documentation**: Added details about the **pkgs integration** to the `mc_install.rst` file, including examples for package metadata files, `pkgs_tasks.yml`, and simplified `tasks.yml`.

---