### PR TITLE
feat: Add support for larger-width screens

### DIFF
--- a/docs/source/_static/vmr_exp.html
+++ b/docs/source/_static/vmr_exp.html
@@ -225,6 +225,7 @@
                 <!-- SVG element for displaying the graph -->
                 <svg id="graph" width="1200" height="800"></svg>
 
+                <!-- 'Reset' SVG icon -->
                 <svg
                     id="resetIcon"
                     xmlns="http://www.w3.org/2000/svg"
@@ -238,7 +239,7 @@
                     />
                 </svg>
 
-                <!-- Download SVG icon -->
+                <!-- 'Download' SVG icon -->
                 <svg
                     id="downloadIcon"
                     xmlns="http://www.w3.org/2000/svg"

--- a/docs/source/_static/vmr_exp.html
+++ b/docs/source/_static/vmr_exp.html
@@ -246,7 +246,7 @@
                     height="50px"
                     viewBox="0 -960 960 960"
                     width="50px"
-                    style="position: absolute; top: 60px; right: 15px; cursor: pointer"
+                    style="top: 60px; right: 15px"
                 >
                     <path
                         d="M480-320 280-520l56-58 104 104v-326h80v326l104-104 56 58-200 200ZM240-160q-33 0-56.5-23.5T160-240v-120h80v120h480v-120h80v120q0 33-23.5 56.5T720-160H240Z"

--- a/docs/source/_static/vmr_exp.html
+++ b/docs/source/_static/vmr_exp.html
@@ -206,7 +206,7 @@
             </div>
 
             <!-- Graph container section -->
-            <div id="graphContainer" style="position: absolute; padding-bottom: 40px">
+            <div id="graphContainer" style="padding-bottom: 40px">
                 <!-- Section title -->
                 <h2>
                     Graph Visualization&nbsp;<svg
@@ -223,7 +223,7 @@
                 </h2>
 
                 <!-- SVG element for displaying the graph -->
-                <svg id="graph" width="1200" height="800"></svg>
+                <svg id="graph"></svg>
 
                 <!-- 'Reset' SVG icon -->
                 <svg

--- a/docs/source/_static/vmr_exp_script.js
+++ b/docs/source/_static/vmr_exp_script.js
@@ -435,11 +435,12 @@ function updateGraph() {
     const color = d3.scaleOrdinal(d3.schemeDark2);
 
     // Create the SVG element for the tangled tree visualization
-    const width = Math.min(tangleLayout.layout.width, 1200); // Set a maximum width
+    const maxWidth = document.getElementById("scheduleContainer").offsetWidth;
+    const width = Math.min(tangleLayout.layout.width, maxWidth); // Set a maximum width
     const height = Math.min(tangleLayout.layout.height, 800); // Set a maximum height
 
-    svg.attr("width", 1200)
-        .attr("height", 800)
+    svg.attr("viewbox", `0 0 ${width} ${height}`)
+        .attr("height", height)
         .style("background-color", background_color);
 
     // Center the graph initially

--- a/docs/source/_static/vmr_exp_styles.css
+++ b/docs/source/_static/vmr_exp_styles.css
@@ -541,3 +541,31 @@ md-outlined-button:hover {
     color: var(--md-sys-color-on-background);
     fill: var(--md-sys-color-on-background);
 }
+
+
+#graphContainer {
+  position: relative;
+}
+
+#graph {
+  width: 100%;
+}
+
+/* Custom container overrides for large-width screens */
+@media (min-width: 1920px) {
+  .container {
+    max-width: 1800px;
+  }
+}
+
+@media (min-width: 2560px) {
+  .container {
+    max-width: 2400px;
+  }
+}
+
+@media (min-width: 3840px) {
+  .container {
+    max-width: 3600px;
+  }
+}


### PR DESCRIPTION
I found that when I viewed the VM Resource explorer on a reasonably large monitor, the hardcoded max-widths were preventing me from getting a nice wide view of the table and graph.

<img width="2556" height="1414" alt="small-width" src="https://github.com/user-attachments/assets/27b1dcfb-a367-4e22-8d5d-e62b63e8f6aa" />

I made a few customizations to the JS/CSS that allow the main `div` for content to adjust a bit larger (loosely following the current schema defined by bootstrap). That covered the table, and then, I synced up the graph so that it's maximum width would match the table size (rather than be fixed at 1200px).

<img width="2560" height="1416" alt="large-width" src="https://github.com/user-attachments/assets/56c9871f-72f4-42f6-98fb-cb3bb7c25f00" />
