### PR TITLE
refactor: Use a consistent timestamp for logging and minimize try-blocks

### DIFF
--- a/src/firewheel/vm_resource_manager/vm_resource_handler.py
+++ b/src/firewheel/vm_resource_manager/vm_resource_handler.py
@@ -744,13 +744,12 @@ class VMResourceHandler:
         Args:
             content (str or dict): Buffer from agent output.
         """
+        timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
         # Handle content that is already a dictionary, i.e. from the handler
         if isinstance(content, dict):
+            content["timestamp"] = timestamp
             try:
                 # Only log a line if it is a JSON object.
-                content["timestamp"] = datetime.now(timezone.utc).strftime(
-                    "%Y-%m-%d %H:%M:%S"
-                )
                 self.json_log.info(json.dumps(content))
             except TypeError:
                 self.log.debug("Could not parse '%s' into JSON formatting.", content)
@@ -764,18 +763,13 @@ class VMResourceHandler:
                 # Only log a line if it can be decoded
                 try:
                     data = json.loads(line.decode())
-                    data["timestamp"] = datetime.now(timezone.utc).strftime(
-                        "%Y-%m-%d %H:%M:%S"
-                    )
                 except (json.JSONDecodeError, TypeError):
                     try:
                         # Convert decoded line into a dict
                         data = {"msg": line.decode()}
-                        data["timestamp"] = datetime.now(timezone.utc).strftime(
-                            "%Y-%m-%d %H:%M:%S"
-                        )
                     except TypeError:
                         return
+                data["timestamp"] = timestamp
                 self.json_log.info(json.dumps(data))
 
     def print_output(self, schedule_entry, pid):


### PR DESCRIPTION
#228 generally looks good to me, though I noticed that our `log_json` method had some repetition. 

This uses a single timestamp for a logging action, rather than repeated calls to `datetime.now`. I think this is probably a better reflection of what's happening (write the timestamp of the time info should be logged, rather than write the timestamp of the time info is actually written to log), and it is more efficient—both fewer calls to `datetime.now` and less happening inside the `try/except` block that could potentially raise a matching exception by accident.

Technically this does (slightly) change the possibility for the output, but since we output `strftime` on the order of seconds, it shouldn't practically be different as those write operations in the `for` loop should happen much faster than that.