### PR TITLE
test: Use pytest fixtures to reduce in-test operations

### DIFF
--- a/src/firewheel/tests/unit/lib/test_lib_discovery_api.py
+++ b/src/firewheel/tests/unit/lib/test_lib_discovery_api.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+from typing import Iterator
 from unittest.mock import Mock, patch
 
 import pytest
@@ -25,6 +26,14 @@ def _mock_config() -> dict:
             "level": "INFO",
         },
     }
+
+
+@pytest.fixture
+def mock_config() -> Iterator[None]:
+    """Patch the discovery API configuration loading with deterministic test values."""
+    with patch("firewheel.lib.discovery.api.Config") as mock_config_cls:
+        mock_config_cls.return_value.get_config.return_value = _mock_config()
+        yield
 
 
 def _build_response(
@@ -50,11 +59,8 @@ def _build_response(
     return response
 
 
-@patch("firewheel.lib.discovery.api.Config")
-def test_init_uses_config_defaults(mock_config_cls) -> None:
+def test_init_uses_config_defaults(mock_config) -> None:
     """Verify discoveryAPI initialization uses configuration defaults."""
-    mock_config_cls.return_value.get_config.return_value = _mock_config()
-
     api = discoveryAPI()
 
     assert api.bind_addr == "discovery-host:9001"
@@ -62,11 +68,8 @@ def test_init_uses_config_defaults(mock_config_cls) -> None:
     assert api.log_file is None
 
 
-@patch("firewheel.lib.discovery.api.Config")
-def test_init_uses_explicit_hostname_port(mock_config_cls) -> None:
+def test_init_uses_explicit_hostname_port(mock_config) -> None:
     """Verify discoveryAPI honors explicit hostname and port overrides."""
-    mock_config_cls.return_value.get_config.return_value = _mock_config()
-
     api = discoveryAPI(hostname="custom-host", port=1234)
 
     assert api.bind_addr == "custom-host:1234"
@@ -74,10 +77,8 @@ def test_init_uses_explicit_hostname_port(mock_config_cls) -> None:
 
 
 @patch("firewheel.lib.discovery.api.requests.get")
-@patch("firewheel.lib.discovery.api.Config")
-def test_test_connection_success(mock_config_cls, mock_get) -> None:
+def test_test_connection_success(mock_get, mock_config) -> None:
     """Verify test_connection returns True for HTTP 200."""
-    mock_config_cls.return_value.get_config.return_value = _mock_config()
     mock_get.return_value = _build_response(status_code=requests.codes.ok)
 
     api = discoveryAPI()
@@ -87,10 +88,8 @@ def test_test_connection_success(mock_config_cls, mock_get) -> None:
 
 
 @patch("firewheel.lib.discovery.api.requests.get")
-@patch("firewheel.lib.discovery.api.Config")
-def test_test_connection_bad_status_returns_false(mock_config_cls, mock_get) -> None:
+def test_test_connection_bad_status_returns_false(mock_get, mock_config) -> None:
     """Verify test_connection returns False for unexpected status codes."""
-    mock_config_cls.return_value.get_config.return_value = _mock_config()
     mock_get.return_value = _build_response(status_code=500)
 
     api = discoveryAPI()
@@ -99,10 +98,8 @@ def test_test_connection_bad_status_returns_false(mock_config_cls, mock_get) -> 
 
 
 @patch("firewheel.lib.discovery.api.requests.get")
-@patch("firewheel.lib.discovery.api.Config")
-def test_test_connection_connection_error(mock_config_cls, mock_get) -> None:
+def test_test_connection_connection_error(mock_get, mock_config) -> None:
     """Verify test_connection returns False on connection failures."""
-    mock_config_cls.return_value.get_config.return_value = _mock_config()
     mock_get.side_effect = requests.exceptions.ConnectionError()
 
     api = discoveryAPI()
@@ -111,10 +108,8 @@ def test_test_connection_connection_error(mock_config_cls, mock_get) -> None:
 
 
 @patch("firewheel.lib.discovery.api.requests.get")
-@patch("firewheel.lib.discovery.api.Config")
-def test_test_connection_invalid_url(mock_config_cls, mock_get) -> None:
+def test_test_connection_invalid_url(mock_get, mock_config) -> None:
     """Verify test_connection returns False for invalid URLs."""
-    mock_config_cls.return_value.get_config.return_value = _mock_config()
     mock_get.side_effect = requests.exceptions.InvalidURL()
 
     api = discoveryAPI()
@@ -122,10 +117,8 @@ def test_test_connection_invalid_url(mock_config_cls, mock_get) -> None:
     assert api.test_connection() is False
 
 
-@patch("firewheel.lib.discovery.api.Config")
-def test_start_discovery_returns_true_if_already_running(mock_config_cls) -> None:
+def test_start_discovery_returns_true_if_already_running(mock_config) -> None:
     """Verify start_discovery returns immediately when service is already running."""
-    mock_config_cls.return_value.get_config.return_value = _mock_config()
     api = discoveryAPI()
 
     with patch.object(api, "test_connection", return_value=True) as test_connection:
@@ -135,12 +128,10 @@ def test_start_discovery_returns_true_if_already_running(mock_config_cls) -> Non
 
 
 @patch("firewheel.lib.discovery.api.minimegaAPI")
-@patch("firewheel.lib.discovery.api.Config")
 def test_start_discovery_runtime_error_returns_false(
-    mock_config_cls, mock_minimega_api_cls
+    mock_minimega_api_cls, mock_config
 ) -> None:
     """Verify start_discovery returns False on minimega runtime errors."""
-    mock_config_cls.return_value.get_config.return_value = _mock_config()
     mock_minimega_api_cls.side_effect = RuntimeError("boom")
 
     api = discoveryAPI()
@@ -150,12 +141,10 @@ def test_start_discovery_runtime_error_returns_false(
 
 
 @patch("firewheel.lib.discovery.api.minimegaAPI")
-@patch("firewheel.lib.discovery.api.Config")
 def test_start_discovery_timeout_error_returns_false(
-    mock_config_cls, mock_minimega_api_cls
+    mock_minimega_api_cls, mock_config
 ) -> None:
     """Verify start_discovery returns False on minimega timeout errors."""
-    mock_config_cls.return_value.get_config.return_value = _mock_config()
     mock_minimega_api_cls.side_effect = TimeoutError("boom")
 
     api = discoveryAPI()
@@ -166,12 +155,10 @@ def test_start_discovery_timeout_error_returns_false(
 
 @patch("firewheel.lib.discovery.api.time.sleep")
 @patch("firewheel.lib.discovery.api.minimegaAPI")
-@patch("firewheel.lib.discovery.api.Config")
 def test_start_discovery_success_after_polling(
-    mock_config_cls, mock_minimega_api_cls, mock_sleep
+    mock_minimega_api_cls, mock_sleep, mock_config
 ) -> None:
     """Verify start_discovery launches discovery and detects startup."""
-    mock_config_cls.return_value.get_config.return_value = _mock_config()
     mock_mm = Mock()
     mock_minimega_api_cls.return_value = mock_mm
 
@@ -190,12 +177,10 @@ def test_start_discovery_success_after_polling(
 
 @patch("firewheel.lib.discovery.api.time.sleep")
 @patch("firewheel.lib.discovery.api.minimegaAPI")
-@patch("firewheel.lib.discovery.api.Config")
 def test_start_discovery_returns_false_after_all_attempts(
-    mock_config_cls, mock_minimega_api_cls, mock_sleep
+    mock_minimega_api_cls, mock_sleep, mock_config
 ) -> None:
     """Verify start_discovery returns False if service never responds."""
-    mock_config_cls.return_value.get_config.return_value = _mock_config()
     mock_minimega_api_cls.return_value = Mock()
 
     api = discoveryAPI()
@@ -210,10 +195,8 @@ def test_start_discovery_returns_false_after_all_attempts(
 
 
 @patch("firewheel.lib.discovery.api.requests.get")
-@patch("firewheel.lib.discovery.api.Config")
-def test_get_config(mock_config_cls, mock_get) -> None:
+def test_get_config(mock_get, mock_config) -> None:
     """Verify get_config returns JSON data from discovery."""
-    mock_config_cls.return_value.get_config.return_value = _mock_config()
     mock_get.return_value = _build_response(json_data={"a": 1})
 
     api = discoveryAPI()
@@ -224,10 +207,8 @@ def test_get_config(mock_config_cls, mock_get) -> None:
 
 
 @patch("firewheel.lib.discovery.api.requests.post")
-@patch("firewheel.lib.discovery.api.Config")
-def test_set_config(mock_config_cls, mock_post) -> None:
+def test_set_config(mock_post, mock_config) -> None:
     """Verify set_config posts data and returns response.ok."""
-    mock_config_cls.return_value.get_config.return_value = _mock_config()
     mock_post.return_value = _build_response(ok=True)
 
     api = discoveryAPI()
@@ -240,10 +221,8 @@ def test_set_config(mock_config_cls, mock_post) -> None:
 
 
 @patch("firewheel.lib.discovery.api.requests.post")
-@patch("firewheel.lib.discovery.api.Config")
-def test_insert_network(mock_config_cls, mock_post) -> None:
+def test_insert_network(mock_post, mock_config) -> None:
     """Verify insert_network posts the expected payload."""
-    mock_config_cls.return_value.get_config.return_value = _mock_config()
     mock_post.return_value = _build_response(json_data=[{"NID": "n1"}])
 
     api = discoveryAPI()
@@ -255,10 +234,8 @@ def test_insert_network(mock_config_cls, mock_post) -> None:
 
 
 @patch("firewheel.lib.discovery.api.requests.get")
-@patch("firewheel.lib.discovery.api.Config")
-def test_get_networks_returns_list(mock_config_cls, mock_get) -> None:
+def test_get_networks_returns_list(mock_get, mock_config) -> None:
     """Verify get_networks returns network data."""
-    mock_config_cls.return_value.get_config.return_value = _mock_config()
     mock_get.return_value = _build_response(json_data=[{"NID": "n1"}])
 
     api = discoveryAPI()
@@ -267,10 +244,8 @@ def test_get_networks_returns_list(mock_config_cls, mock_get) -> None:
 
 
 @patch("firewheel.lib.discovery.api.requests.get")
-@patch("firewheel.lib.discovery.api.Config")
-def test_get_networks_returns_empty_list_on_none(mock_config_cls, mock_get) -> None:
+def test_get_networks_returns_empty_list_on_none(mock_get, mock_config) -> None:
     """Verify get_networks normalizes None responses to an empty list."""
-    mock_config_cls.return_value.get_config.return_value = _mock_config()
     mock_get.return_value = _build_response(json_data=None)
 
     api = discoveryAPI()
@@ -279,10 +254,8 @@ def test_get_networks_returns_empty_list_on_none(mock_config_cls, mock_get) -> N
 
 
 @patch("firewheel.lib.discovery.api.requests.delete")
-@patch("firewheel.lib.discovery.api.Config")
-def test_delete_networks_with_key_and_value(mock_config_cls, mock_delete) -> None:
+def test_delete_networks_with_key_and_value(mock_delete, mock_config) -> None:
     """Verify delete_networks uses the key/value endpoint when both are provided."""
-    mock_config_cls.return_value.get_config.return_value = _mock_config()
     mock_delete.return_value = _build_response(json_data=[{"NID": "n1"}])
 
     api = discoveryAPI()
@@ -294,10 +267,8 @@ def test_delete_networks_with_key_and_value(mock_config_cls, mock_delete) -> Non
 
 
 @patch("firewheel.lib.discovery.api.requests.delete")
-@patch("firewheel.lib.discovery.api.Config")
-def test_delete_networks_with_value_only(mock_config_cls, mock_delete) -> None:
+def test_delete_networks_with_value_only(mock_delete, mock_config) -> None:
     """Verify delete_networks uses the value-only endpoint when key is omitted."""
-    mock_config_cls.return_value.get_config.return_value = _mock_config()
     mock_delete.return_value = _build_response(json_data=[{"NID": "n1"}])
 
     api = discoveryAPI()
@@ -307,12 +278,10 @@ def test_delete_networks_with_value_only(mock_config_cls, mock_delete) -> None:
 
 
 @patch("firewheel.lib.discovery.api.requests.delete")
-@patch("firewheel.lib.discovery.api.Config")
 def test_delete_networks_returns_empty_list_on_none(
-    mock_config_cls, mock_delete
+    mock_delete, mock_config
 ) -> None:
     """Verify delete_networks normalizes None responses to an empty list."""
-    mock_config_cls.return_value.get_config.return_value = _mock_config()
     mock_delete.return_value = _build_response(json_data=None)
 
     api = discoveryAPI()
@@ -321,10 +290,8 @@ def test_delete_networks_returns_empty_list_on_none(
 
 
 @patch("firewheel.lib.discovery.api.requests.get")
-@patch("firewheel.lib.discovery.api.Config")
-def test_get_endpoints_returns_list(mock_config_cls, mock_get) -> None:
+def test_get_endpoints_returns_list(mock_get, mock_config) -> None:
     """Verify get_endpoints returns endpoint data."""
-    mock_config_cls.return_value.get_config.return_value = _mock_config()
     mock_get.return_value = _build_response(json_data=[{"NID": "e1"}])
 
     api = discoveryAPI()
@@ -333,10 +300,8 @@ def test_get_endpoints_returns_list(mock_config_cls, mock_get) -> None:
 
 
 @patch("firewheel.lib.discovery.api.requests.get")
-@patch("firewheel.lib.discovery.api.Config")
-def test_get_endpoints_returns_empty_list_on_none(mock_config_cls, mock_get) -> None:
+def test_get_endpoints_returns_empty_list_on_none(mock_get, mock_config) -> None:
     """Verify get_endpoints normalizes None responses to an empty list."""
-    mock_config_cls.return_value.get_config.return_value = _mock_config()
     mock_get.return_value = _build_response(json_data=None)
 
     api = discoveryAPI()
@@ -345,10 +310,8 @@ def test_get_endpoints_returns_empty_list_on_none(mock_config_cls, mock_get) -> 
 
 
 @patch("firewheel.lib.discovery.api.requests.delete")
-@patch("firewheel.lib.discovery.api.Config")
-def test_delete_endpoints_with_key_and_value(mock_config_cls, mock_delete) -> None:
+def test_delete_endpoints_with_key_and_value(mock_delete, mock_config) -> None:
     """Verify delete_endpoints uses the key/value endpoint when both are provided."""
-    mock_config_cls.return_value.get_config.return_value = _mock_config()
     mock_delete.return_value = _build_response(json_data=[{"NID": "e1"}])
 
     api = discoveryAPI()
@@ -360,10 +323,8 @@ def test_delete_endpoints_with_key_and_value(mock_config_cls, mock_delete) -> No
 
 
 @patch("firewheel.lib.discovery.api.requests.delete")
-@patch("firewheel.lib.discovery.api.Config")
-def test_delete_endpoints_with_value_only(mock_config_cls, mock_delete) -> None:
+def test_delete_endpoints_with_value_only(mock_delete, mock_config) -> None:
     """Verify delete_endpoints uses the value-only endpoint when key is omitted."""
-    mock_config_cls.return_value.get_config.return_value = _mock_config()
     mock_delete.return_value = _build_response(json_data=[{"NID": "e1"}])
 
     api = discoveryAPI()
@@ -375,12 +336,10 @@ def test_delete_endpoints_with_value_only(mock_config_cls, mock_delete) -> None:
 
 
 @patch("firewheel.lib.discovery.api.requests.delete")
-@patch("firewheel.lib.discovery.api.Config")
 def test_delete_endpoints_returns_empty_list_on_none(
-    mock_config_cls, mock_delete
+    mock_delete, mock_config
 ) -> None:
     """Verify delete_endpoints normalizes None responses to an empty list."""
-    mock_config_cls.return_value.get_config.return_value = _mock_config()
     mock_delete.return_value = _build_response(json_data=None)
 
     api = discoveryAPI()
@@ -388,20 +347,16 @@ def test_delete_endpoints_returns_empty_list_on_none(
     assert api.delete_endpoints(value="qemu") == []
 
 
-@patch("firewheel.lib.discovery.api.Config")
-def test_delete_all_endpoints_empty(mock_config_cls) -> None:
+def test_delete_all_endpoints_empty(mock_config) -> None:
     """Verify delete_all_endpoints returns empty when no endpoints exist."""
-    mock_config_cls.return_value.get_config.return_value = _mock_config()
     api = discoveryAPI()
 
     with patch.object(api, "get_endpoints", return_value=[]):
         assert api.delete_all_endpoints() == []
 
 
-@patch("firewheel.lib.discovery.api.Config")
-def test_delete_all_endpoints_only_qemu_needed(mock_config_cls) -> None:
+def test_delete_all_endpoints_only_qemu_needed(mock_config) -> None:
     """Verify delete_all_endpoints stops after qemu deletion if no endpoints remain."""
-    mock_config_cls.return_value.get_config.return_value = _mock_config()
     api = discoveryAPI()
 
     with (
@@ -415,10 +370,8 @@ def test_delete_all_endpoints_only_qemu_needed(mock_config_cls) -> None:
     delete_endpoints.assert_called_once_with(value="qemu")
 
 
-@patch("firewheel.lib.discovery.api.Config")
-def test_delete_all_endpoints_deletes_remaining_by_nid(mock_config_cls) -> None:
+def test_delete_all_endpoints_deletes_remaining_by_nid(mock_config) -> None:
     """Verify delete_all_endpoints deletes remaining endpoints by NID."""
-    mock_config_cls.return_value.get_config.return_value = _mock_config()
     api = discoveryAPI()
 
     remaining = [{"NID": "e2"}, {"NID": "e3"}]
@@ -439,20 +392,16 @@ def test_delete_all_endpoints_deletes_remaining_by_nid(mock_config_cls) -> None:
     assert delete_endpoints.call_args_list[2].kwargs == {"key": "NID", "value": "e3"}
 
 
-@patch("firewheel.lib.discovery.api.Config")
-def test_delete_all_networks_empty(mock_config_cls) -> None:
+def test_delete_all_networks_empty(mock_config) -> None:
     """Verify delete_all_networks returns empty when no networks exist."""
-    mock_config_cls.return_value.get_config.return_value = _mock_config()
     api = discoveryAPI()
 
     with patch.object(api, "get_networks", return_value=[]):
         assert api.delete_all_networks() == []
 
 
-@patch("firewheel.lib.discovery.api.Config")
-def test_delete_all_networks(mock_config_cls) -> None:
+def test_delete_all_networks(mock_config) -> None:
     """Verify delete_all_networks deletes each network by NID."""
-    mock_config_cls.return_value.get_config.return_value = _mock_config()
     api = discoveryAPI()
 
     with (
@@ -470,10 +419,8 @@ def test_delete_all_networks(mock_config_cls) -> None:
     assert delete_networks.call_args_list[1].kwargs == {"key": "NID", "value": "n2"}
 
 
-@patch("firewheel.lib.discovery.api.Config")
-def test_delete_all_success(mock_config_cls) -> None:
+def test_delete_all_success(mock_config) -> None:
     """Verify delete_all returns True when endpoints and networks are cleared."""
-    mock_config_cls.return_value.get_config.return_value = _mock_config()
     api = discoveryAPI()
 
     with (
@@ -485,10 +432,8 @@ def test_delete_all_success(mock_config_cls) -> None:
         assert api.delete_all() is True
 
 
-@patch("firewheel.lib.discovery.api.Config")
-def test_delete_all_raises_for_remaining_endpoints(mock_config_cls) -> None:
+def test_delete_all_raises_for_remaining_endpoints(mock_config) -> None:
     """Verify delete_all raises if endpoints remain after deletion."""
-    mock_config_cls.return_value.get_config.return_value = _mock_config()
     api = discoveryAPI()
 
     with (
@@ -499,10 +444,8 @@ def test_delete_all_raises_for_remaining_endpoints(mock_config_cls) -> None:
             api.delete_all()
 
 
-@patch("firewheel.lib.discovery.api.Config")
-def test_delete_all_raises_for_remaining_networks(mock_config_cls) -> None:
+def test_delete_all_raises_for_remaining_networks(mock_config) -> None:
     """Verify delete_all raises if networks remain after deletion."""
-    mock_config_cls.return_value.get_config.return_value = _mock_config()
     api = discoveryAPI()
 
     with (
@@ -516,10 +459,8 @@ def test_delete_all_raises_for_remaining_networks(mock_config_cls) -> None:
 
 
 @patch("firewheel.lib.discovery.api.requests.post")
-@patch("firewheel.lib.discovery.api.Config")
-def test_insert_endpoint(mock_config_cls, mock_post) -> None:
+def test_insert_endpoint(mock_post, mock_config) -> None:
     """Verify insert_endpoint posts wrapped node properties."""
-    mock_config_cls.return_value.get_config.return_value = _mock_config()
     mock_post.return_value = _build_response(json_data=[{"NID": "e1"}])
 
     api = discoveryAPI()
@@ -534,10 +475,8 @@ def test_insert_endpoint(mock_config_cls, mock_post) -> None:
 
 
 @patch("firewheel.lib.discovery.api.requests.put")
-@patch("firewheel.lib.discovery.api.Config")
-def test_update_endpoint(mock_config_cls, mock_put) -> None:
+def test_update_endpoint(mock_put, mock_config) -> None:
     """Verify update_endpoint sends the given node properties."""
-    mock_config_cls.return_value.get_config.return_value = _mock_config()
     mock_put.return_value = _build_response(json_data=[{"NID": "e1"}])
 
     api = discoveryAPI()
@@ -552,10 +491,8 @@ def test_update_endpoint(mock_config_cls, mock_put) -> None:
 
 
 @patch("firewheel.lib.discovery.api.requests.post")
-@patch("firewheel.lib.discovery.api.Config")
-def test_connect_endpoint(mock_config_cls, mock_post) -> None:
+def test_connect_endpoint(mock_post, mock_config) -> None:
     """Verify connect_endpoint posts to the correct connect URI."""
-    mock_config_cls.return_value.get_config.return_value = _mock_config()
     mock_post.return_value = _build_response(json_data={"NID": "e1", "network": "n1"})
 
     api = discoveryAPI()
@@ -567,10 +504,8 @@ def test_connect_endpoint(mock_config_cls, mock_post) -> None:
 
 
 @patch("firewheel.lib.discovery.api.requests.get")
-@patch("firewheel.lib.discovery.api.Config")
-def test_get_config_propagates_json_error(mock_config_cls, mock_get) -> None:
+def test_get_config_propagates_json_error(mock_get, mock_config) -> None:
     """Verify malformed JSON from discovery propagates."""
-    mock_config_cls.return_value.get_config.return_value = _mock_config()
     response = _build_response()
     response.json.side_effect = ValueError("bad json")
     mock_get.return_value = response
@@ -582,10 +517,8 @@ def test_get_config_propagates_json_error(mock_config_cls, mock_get) -> None:
 
 
 @patch("firewheel.lib.discovery.api.requests.post")
-@patch("firewheel.lib.discovery.api.Config")
-def test_set_config_propagates_http_error(mock_config_cls, mock_post) -> None:
+def test_set_config_propagates_http_error(mock_post, mock_config) -> None:
     """Verify HTTP errors from set_config are propagated."""
-    mock_config_cls.return_value.get_config.return_value = _mock_config()
     response = _build_response()
     response.raise_for_status.side_effect = requests.HTTPError("boom")
     mock_post.return_value = response
@@ -596,10 +529,8 @@ def test_set_config_propagates_http_error(mock_config_cls, mock_post) -> None:
         api.set_config("foo", {"bar": 1})
 
 
-@patch("firewheel.lib.discovery.api.Config")
-def test_delete_all_endpoints_raises_on_missing_nid(mock_config_cls) -> None:
+def test_delete_all_endpoints_raises_on_missing_nid(mock_config) -> None:
     """Verify delete_all_endpoints fails clearly on malformed endpoint data."""
-    mock_config_cls.return_value.get_config.return_value = _mock_config()
     api = discoveryAPI()
 
     with (
@@ -610,10 +541,8 @@ def test_delete_all_endpoints_raises_on_missing_nid(mock_config_cls) -> None:
             api.delete_all_endpoints()
 
 
-@patch("firewheel.lib.discovery.api.Config")
-def test_delete_all_networks_raises_on_missing_nid(mock_config_cls) -> None:
+def test_delete_all_networks_raises_on_missing_nid(mock_config) -> None:
     """Verify delete_all_networks fails clearly on malformed network data."""
-    mock_config_cls.return_value.get_config.return_value = _mock_config()
     api = discoveryAPI()
 
     with patch.object(api, "get_networks", return_value=[{"bad": 1}]):
@@ -622,10 +551,8 @@ def test_delete_all_networks_raises_on_missing_nid(mock_config_cls) -> None:
 
 
 @patch("firewheel.lib.discovery.api.requests.post")
-@patch("firewheel.lib.discovery.api.Config")
-def test_insert_endpoint_accepts_none_properties(mock_config_cls, mock_post) -> None:
+def test_insert_endpoint_accepts_none_properties(mock_post, mock_config) -> None:
     """Verify insert_endpoint wraps None in the expected payload shape."""
-    mock_config_cls.return_value.get_config.return_value = _mock_config()
     mock_post.return_value = _build_response(json_data=[{"NID": "e1"}])
 
     api = discoveryAPI()

--- a/src/firewheel/tests/unit/lib/test_lib_grpc_server.py
+++ b/src/firewheel/tests/unit/lib/test_lib_grpc_server.py
@@ -46,22 +46,25 @@ def _build_servicer_without_init() -> FirewheelServicer:
     return servicer
 
 
-def test_get_vm_mapping_found() -> None:
+@pytest.fixture
+def servicer() -> FirewheelServicer:
+    """Create a fresh ``FirewheelServicer`` test instance for each test."""
+    return _build_servicer_without_init()
+
+
+def test_get_vm_mapping_found(servicer) -> None:
     """Verify get_vm_mapping returns found entries."""
-    servicer = _build_servicer_without_init()
     vm = Mock()
     assert servicer.get_vm_mapping({"uuid": vm}, "uuid") is vm
 
 
-def test_get_vm_mapping_missing() -> None:
+def test_get_vm_mapping_missing(servicer) -> None:
     """Verify get_vm_mapping returns None on missing keys."""
-    servicer = _build_servicer_without_init()
     assert servicer.get_vm_mapping({}, "uuid") is None
 
 
-def test_init_db() -> None:
+def test_init_db(servicer) -> None:
     """Verify _init_db creates expected database structure."""
-    servicer = _build_servicer_without_init()
     servicer.dbs = {}
     servicer._init_db("prod")
 
@@ -70,18 +73,16 @@ def test_init_db() -> None:
     assert servicer.dbs["prod"]["not_ready_vmms"] == set()
 
 
-def test_get_info() -> None:
+def test_get_info(servicer) -> None:
     """Verify server info reports version and experiment status."""
-    servicer = _build_servicer_without_init()
     response = servicer.GetInfo(Mock(), Mock())
     assert response.version == "1.2.3"
     assert response.uptime >= 0
     assert response.experiment_running is False
 
 
-def test_set_and_get_experiment_launch_time() -> None:
+def test_set_and_get_experiment_launch_time(servicer) -> None:
     """Verify launch time can be stored and retrieved."""
-    servicer = _build_servicer_without_init()
     request = Mock()
     request.db = "prod"
 
@@ -89,9 +90,8 @@ def test_set_and_get_experiment_launch_time() -> None:
     assert servicer.GetExperimentLaunchTime(request, Mock()) is request
 
 
-def test_get_experiment_launch_time_missing_aborts() -> None:
+def test_get_experiment_launch_time_missing_aborts(servicer) -> None:
     """Verify missing launch time aborts with OUT_OF_RANGE."""
-    servicer = _build_servicer_without_init()
     request = Mock()
     request.db = "prod"
 
@@ -101,9 +101,8 @@ def test_get_experiment_launch_time_missing_aborts() -> None:
     assert exc.value.args[0][0] == grpc.StatusCode.OUT_OF_RANGE
 
 
-def test_set_and_get_experiment_start_time() -> None:
+def test_set_and_get_experiment_start_time(servicer) -> None:
     """Verify start time can be stored and retrieved."""
-    servicer = _build_servicer_without_init()
     request = Mock()
     request.db = "prod"
 
@@ -111,9 +110,8 @@ def test_set_and_get_experiment_start_time() -> None:
     assert servicer.GetExperimentStartTime(request, Mock()) is request
 
 
-def test_get_experiment_start_time_missing_aborts() -> None:
+def test_get_experiment_start_time_missing_aborts(servicer) -> None:
     """Verify missing start time aborts with OUT_OF_RANGE."""
-    servicer = _build_servicer_without_init()
     request = Mock()
     request.db = "prod"
 
@@ -123,9 +121,8 @@ def test_get_experiment_start_time_missing_aborts() -> None:
     assert exc.value.args[0][0] == grpc.StatusCode.OUT_OF_RANGE
 
 
-def test_initialize_experiment_start_time() -> None:
+def test_initialize_experiment_start_time(servicer) -> None:
     """Verify initialization clears launch/start time state."""
-    servicer = _build_servicer_without_init()
     servicer.dbs["prod"]["experiment_launch_time"] = Mock()
     servicer.dbs["prod"]["experiment_start_times"] = [Mock()]
 
@@ -138,9 +135,8 @@ def test_initialize_experiment_start_time() -> None:
     assert servicer.dbs["prod"]["experiment_start_times"] == []
 
 
-def test_count_vm_mappings_not_ready() -> None:
+def test_count_vm_mappings_not_ready(servicer) -> None:
     """Verify not-ready VM count is returned."""
-    servicer = _build_servicer_without_init()
     servicer.dbs["prod"]["not_ready_vmms"] = {"a", "b"}
     request = Mock()
     request.db = "prod"
@@ -149,9 +145,8 @@ def test_count_vm_mappings_not_ready() -> None:
     assert response.count == 2
 
 
-def test_get_vm_mapping_by_uuid_found() -> None:
+def test_get_vm_mapping_by_uuid_found(servicer) -> None:
     """Verify UUID lookup returns the stored mapping."""
-    servicer = _build_servicer_without_init()
     vm = Mock()
     servicer.dbs["prod"]["vm_mappings"]["uuid"] = vm
     request = Mock()
@@ -161,9 +156,8 @@ def test_get_vm_mapping_by_uuid_found() -> None:
     assert servicer.GetVMMappingByUUID(request, Mock()) is vm
 
 
-def test_get_vm_mapping_by_uuid_missing_aborts() -> None:
+def test_get_vm_mapping_by_uuid_missing_aborts(servicer) -> None:
     """Verify missing UUID lookup aborts with OUT_OF_RANGE."""
-    servicer = _build_servicer_without_init()
     request = Mock()
     request.db = "prod"
     request.server_uuid = "missing"
@@ -174,9 +168,8 @@ def test_get_vm_mapping_by_uuid_missing_aborts() -> None:
     assert exc.value.args[0][0] == grpc.StatusCode.OUT_OF_RANGE
 
 
-def test_set_vm_time_by_uuid() -> None:
+def test_set_vm_time_by_uuid(servicer) -> None:
     """Verify VM current time can be updated."""
-    servicer = _build_servicer_without_init()
     vm = Mock()
     servicer.dbs["prod"]["vm_mappings"]["uuid"] = vm
 
@@ -190,10 +183,8 @@ def test_set_vm_time_by_uuid() -> None:
     assert vm.current_time == "123"
 
 
-def test_update_not_ready_vmms_add_and_remove() -> None:
+def test_update_not_ready_vmms_add_and_remove(servicer) -> None:
     """Verify VM readiness tracking set updates correctly."""
-    servicer = _build_servicer_without_init()
-
     vmm = Mock()
     vmm.state = "BOOTING"
     vmm.server_uuid = "uuid"
@@ -205,9 +196,8 @@ def test_update_not_ready_vmms_add_and_remove() -> None:
     assert "uuid" not in servicer.dbs["prod"]["not_ready_vmms"]
 
 
-def test_set_vm_state_by_uuid() -> None:
+def test_set_vm_state_by_uuid(servicer) -> None:
     """Verify VM state updates modify stored mappings."""
-    servicer = _build_servicer_without_init()
     vm = Mock()
     servicer.dbs["prod"]["vm_mappings"]["uuid"] = vm
 
@@ -221,9 +211,8 @@ def test_set_vm_state_by_uuid() -> None:
     assert vm.state == "RUNNING"
 
 
-def test_destroy_vm_mapping_by_uuid() -> None:
+def test_destroy_vm_mapping_by_uuid(servicer) -> None:
     """Verify a VM mapping and readiness entry can be removed."""
-    servicer = _build_servicer_without_init()
     servicer.dbs["prod"]["vm_mappings"]["uuid"] = Mock()
     servicer.dbs["prod"]["not_ready_vmms"].add("uuid")
 
@@ -237,9 +226,8 @@ def test_destroy_vm_mapping_by_uuid() -> None:
     assert "uuid" not in servicer.dbs["prod"]["not_ready_vmms"]
 
 
-def test_set_vm_mapping() -> None:
+def test_set_vm_mapping(servicer) -> None:
     """Verify SetVMMapping stores the provided request object."""
-    servicer = _build_servicer_without_init()
     request = Mock()
     request.db = "prod"
     request.server_uuid = "uuid"
@@ -250,9 +238,8 @@ def test_set_vm_mapping() -> None:
     assert servicer.dbs["prod"]["vm_mappings"]["uuid"] is request
 
 
-def test_destroy_all_vm_mappings() -> None:
+def test_destroy_all_vm_mappings(servicer) -> None:
     """Verify all VM mappings and readiness tracking are cleared."""
-    servicer = _build_servicer_without_init()
     servicer.dbs["prod"]["vm_mappings"] = {"uuid": Mock()}
     servicer.dbs["prod"]["not_ready_vmms"] = {"uuid"}
 
@@ -299,10 +286,8 @@ def test_serve_startup_path() -> None:
     server.stop.assert_called_once_with(0)
 
 
-def test_set_vm_state_by_uuid_missing_aborts() -> None:
+def test_set_vm_state_by_uuid_missing_aborts(servicer) -> None:
     """Verify missing VM mapping during state update aborts."""
-    servicer = _build_servicer_without_init()
-
     request = __import__("unittest").mock.Mock()
     request.db = "prod"
     request.server_uuid = "missing"

--- a/src/firewheel/tests/unit/lib/test_lib_log.py
+++ b/src/firewheel/tests/unit/lib/test_lib_log.py
@@ -3,49 +3,45 @@
 
 from __future__ import annotations
 
+from typing import Iterator
 import logging
 from unittest.mock import patch
+
+import pytest
 
 from firewheel.lib.log import Log, UTCLog
 
 
-def test_log_creates_handler(tmp_path, monkeypatch) -> None:
-    """Verify a file handler is created for a new logger."""
+@pytest.fixture
+def mock_config(tmp_path, monkeypatch) -> Iterator[dict]:
+    """Configure logging-related settings for tests and yield the config."""
     from firewheel.config import config
 
     monkeypatch.setitem(config["logging"], "root_dir", str(tmp_path))
     monkeypatch.setitem(config["logging"], "firewheel_log", "firewheel.log")
     monkeypatch.setitem(config["logging"], "level", "INFO")
     monkeypatch.setitem(config["system"], "default_group", "")
+    yield config
 
+
+def test_log_creates_handler(mock_config) -> None:
+    """Verify a file handler is created for a new logger."""
     logger = Log("test_log_handler").log
     assert logger.handlers
     assert isinstance(logger.handlers[0], logging.FileHandler)
 
 
-def test_log_uses_null_handler_on_bad_root_dir(monkeypatch) -> None:
+def test_log_uses_null_handler_on_bad_root_dir(mock_config, monkeypatch) -> None:
     """Verify a null handler is used when log path construction fails."""
-    from firewheel.config import config
-
-    monkeypatch.setitem(config["logging"], "root_dir", 1234)
-    monkeypatch.setitem(config["logging"], "firewheel_log", "firewheel.log")
-    monkeypatch.setitem(config["logging"], "level", "INFO")
-    monkeypatch.setitem(config["system"], "default_group", "")
+    monkeypatch.setitem(mock_config["logging"], "root_dir", 1234)
 
     logger = Log("test_bad_root_dir").log
     assert logger.handlers
     assert isinstance(logger.handlers[0], logging.NullHandler)
 
 
-def test_log_falls_back_to_second_try_file(tmp_path, monkeypatch) -> None:
+def test_log_falls_back_to_second_try_file(mock_config) -> None:
     """Verify logger falls back to a username-suffixed file on IOError."""
-    from firewheel.config import config
-
-    monkeypatch.setitem(config["logging"], "root_dir", str(tmp_path))
-    monkeypatch.setitem(config["logging"], "firewheel_log", "firewheel.log")
-    monkeypatch.setitem(config["logging"], "level", "INFO")
-    monkeypatch.setitem(config["system"], "default_group", "")
-
     original_file_handler = logging.FileHandler
 
     call_count = {"count": 0}
@@ -63,42 +59,29 @@ def test_log_falls_back_to_second_try_file(tmp_path, monkeypatch) -> None:
     assert call_count["count"] == 2
 
 
-def test_utclog_uses_gmtime(tmp_path, monkeypatch) -> None:
+def test_utclog_uses_gmtime(mock_config, monkeypatch) -> None:
     """Verify UTCLog configures its formatter for UTC conversion."""
-    from firewheel.config import config
-
-    monkeypatch.setitem(config["logging"], "root_dir", str(tmp_path))
-    monkeypatch.setitem(config["logging"], "firewheel_log", "utc.log")
-    monkeypatch.setitem(config["logging"], "level", "INFO")
-    monkeypatch.setitem(config["system"], "default_group", "")
+    monkeypatch.setitem(mock_config["logging"], "firewheel_log", "utc.log")
 
     logger = UTCLog("test_utc_log").log
     formatter = logger.handlers[0].formatter
     assert formatter.converter is not None
 
 
-def test_log_warns_on_missing_group(tmp_path, monkeypatch) -> None:
+def test_log_warns_on_missing_group(mock_config, monkeypatch) -> None:
     """Verify missing configured group emits a warning path."""
-    from firewheel.config import config
-
-    monkeypatch.setitem(config["logging"], "root_dir", str(tmp_path))
-    monkeypatch.setitem(config["logging"], "firewheel_log", "group_missing.log")
-    monkeypatch.setitem(config["logging"], "level", "INFO")
-    monkeypatch.setitem(config["system"], "default_group", "definitely_missing_group")
+    monkeypatch.setitem(mock_config["logging"], "firewheel_log", "group_missing.log")
+    monkeypatch.setitem(mock_config["system"], "default_group", "definitely_missing_group")
 
     logger = Log("test_log_missing_group").log
     assert logger.handlers
     assert isinstance(logger.handlers[0], logging.FileHandler)
 
 
-def test_log_warning_on_chown_failure(tmp_path, monkeypatch) -> None:
+def test_log_warning_on_chown_failure(mock_config, monkeypatch) -> None:
     """Verify chown failures are tolerated and logger still initializes."""
-    from firewheel.config import config
-
-    monkeypatch.setitem(config["logging"], "root_dir", str(tmp_path))
-    monkeypatch.setitem(config["logging"], "firewheel_log", "chown_failure.log")
-    monkeypatch.setitem(config["logging"], "level", "INFO")
-    monkeypatch.setitem(config["system"], "default_group", "root")
+    monkeypatch.setitem(mock_config["logging"], "firewheel_log", "chown_failure.log")
+    monkeypatch.setitem(mock_config["system"], "default_group", "root")
 
     class FakeGroup:
         """Simple group record."""
@@ -122,14 +105,9 @@ def test_log_warning_on_chown_failure(tmp_path, monkeypatch) -> None:
     assert isinstance(logger.handlers[0], logging.FileHandler)
 
 
-def test_log_second_try_also_fails_uses_nullhandler(tmp_path, monkeypatch) -> None:
+def test_log_second_try_also_fails_uses_nullhandler(mock_config, monkeypatch) -> None:
     """Verify logger falls back to NullHandler if both file opens fail."""
-    from firewheel.config import config
-
-    monkeypatch.setitem(config["logging"], "root_dir", str(tmp_path))
-    monkeypatch.setitem(config["logging"], "firewheel_log", "double_fail.log")
-    monkeypatch.setitem(config["logging"], "level", "INFO")
-    monkeypatch.setitem(config["system"], "default_group", "")
+    monkeypatch.setitem(mock_config["logging"], "firewheel_log", "double_fail.log")
 
     with patch("firewheel.lib.log.logging.FileHandler", side_effect=IOError("fail")):
         logger = Log("test_log_double_fail").log

--- a/src/firewheel/tests/unit/lib/test_lib_minimega_api.py
+++ b/src/firewheel/tests/unit/lib/test_lib_minimega_api.py
@@ -13,6 +13,14 @@ import pytest
 from firewheel.lib.minimega.api import minimegaAPI
 
 
+@pytest.fixture
+def config() -> dict:
+    """Return the mutable FIREWHEEL configuration used by minimega tests."""
+    from firewheel.config import config
+
+    return config
+
+
 def _build_api_without_init() -> minimegaAPI:
     """Create a minimegaAPI instance without running __init__."""
     api = object.__new__(minimegaAPI)
@@ -23,18 +31,20 @@ def _build_api_without_init() -> minimegaAPI:
     return api
 
 
-def test_get_head_node(monkeypatch) -> None:
-    """Verify the head node is read from configuration."""
-    from firewheel.config import config
+@pytest.fixture
+def mock_mm_api() -> minimegaAPI:
+    """A mocked ``minimegaAPI`` object."""
+    return _build_api_without_init()
 
+
+def test_get_head_node(config, monkeypatch) -> None:
+    """Verify the head node is read from configuration."""
     monkeypatch.setitem(config["cluster"], "control", ["headnode"])
     assert minimegaAPI.get_head_node() == "headnode"
 
 
-def test_get_head_node_raises_when_missing(monkeypatch) -> None:
+def test_get_head_node_raises_when_missing(config, monkeypatch) -> None:
     """Verify missing cluster control nodes raise RuntimeError."""
-    from firewheel.config import config
-
     monkeypatch.setitem(config["cluster"], "control", [])
     with pytest.raises(RuntimeError):
         minimegaAPI.get_head_node()
@@ -46,10 +56,8 @@ def test_get_am_head_node(monkeypatch) -> None:
         assert minimegaAPI.get_am_head_node() is True
 
 
-def test_check_version_success() -> None:
+def test_check_version_success(mock_mm_api) -> None:
     """Verify version check returns queue result when child finishes."""
-    api = _build_api_without_init()
-
     queue = Mock()
     queue.get.return_value = True
 
@@ -60,13 +68,11 @@ def test_check_version_success() -> None:
         patch("firewheel.lib.minimega.api.multiprocessing.Queue", return_value=queue),
         patch("firewheel.lib.minimega.api.multiprocessing.Process", return_value=proc),
     ):
-        assert api._check_version(timeout=1, skip_retry=False) is True
+        assert mock_mm_api._check_version(timeout=1, skip_retry=False) is True
 
 
-def test_check_version_timeout_raises_runtimeerror_when_skip_retry() -> None:
+def test_check_version_timeout_raises_runtimeerror_when_skip_retry(mock_mm_api) -> None:
     """Verify version check raises RuntimeError when skip_retry is enabled."""
-    api = _build_api_without_init()
-
     queue = Mock()
     proc = Mock()
     proc.is_alive.return_value = True
@@ -76,55 +82,50 @@ def test_check_version_timeout_raises_runtimeerror_when_skip_retry() -> None:
         patch("firewheel.lib.minimega.api.multiprocessing.Process", return_value=proc),
     ):
         with pytest.raises(RuntimeError):
-            api._check_version(timeout=1, skip_retry=True)
+            mock_mm_api._check_version(timeout=1, skip_retry=True)
 
 
-def test_set_group_perms_success() -> None:
+def test_set_group_perms_success(mock_mm_api) -> None:
     """Verify recursive chmod succeeds on clean minimega response."""
-    api = _build_api_without_init()
-    api.mm.shell.return_value = [{"Error": ""}]
+    mock_mm_api.mm.shell.return_value = [{"Error": ""}]
 
-    assert api.set_group_perms("/tmp/mm/subdir") is True
-    api.mm.shell.assert_called_once()
+    assert mock_mm_api.set_group_perms("/tmp/mm/subdir") is True
+    mock_mm_api.mm.shell.assert_called_once()
 
 
-def test_set_group_perms_failure() -> None:
+def test_set_group_perms_failure(mock_mm_api) -> None:
     """Verify recursive chmod failure returns False."""
-    api = _build_api_without_init()
-    api.mm.shell.return_value = [{"Error": "bad"}]
+    mock_mm_api.mm.shell.return_value = [{"Error": "bad"}]
 
-    assert api.set_group_perms("/tmp/mm/subdir") is False
+    assert mock_mm_api.set_group_perms("/tmp/mm/subdir") is False
 
 
-def test_ns_kill_processes_success() -> None:
+def test_ns_kill_processes_success(mock_mm_api) -> None:
     """Verify namespace kill returns True when command succeeds."""
-    api = _build_api_without_init()
-    assert api.ns_kill_processes("script.py") is True
+    assert mock_mm_api.ns_kill_processes("script.py") is True
 
 
-def test_ns_kill_processes_status_1_returns_false() -> None:
+def test_ns_kill_processes_status_1_returns_false(mock_mm_api) -> None:
     """Verify namespace kill treats status 1 as no processes killed."""
-    api = _build_api_without_init()
 
     class FakeError(Exception):
         """Simple stand-in error."""
 
     with patch("firewheel.lib.minimega.api.minimega.Error", FakeError):
-        api.mm.ns_run.side_effect = FakeError("status 1")
-        assert api.ns_kill_processes("script.py") is False
+        mock_mm_api.mm.ns_run.side_effect = FakeError("status 1")
+        assert mock_mm_api.ns_kill_processes("script.py") is False
 
 
-def test_get_mesh_size() -> None:
+def test_get_mesh_size(mock_mm_api) -> None:
     """Verify mesh size is parsed from mesh_status output."""
-    api = _build_api_without_init()
-    api.mm.mesh_status.return_value = [
+    mock_mm_api.mm.mesh_status.return_value = [
         {
             "Header": ["size"],
             "Tabular": [["3"]],
             "Host": "host",
         }
     ]
-    assert api.get_mesh_size() == 3
+    assert mock_mm_api.get_mesh_size() == 3
 
 
 def test_mmr_map() -> None:
@@ -168,10 +169,9 @@ def test_check_host_filter_unsupported() -> None:
         minimegaAPI.check_host_filter({"state": (">", "running")}, {"state": "running"})
 
 
-def test_mm_vms() -> None:
+def test_mm_vms(mock_mm_api) -> None:
     """Verify VM info is normalized into the expected structure."""
-    api = _build_api_without_init()
-    api.mm.vm_info.return_value = [
+    mock_mm_api.mm.vm_info.return_value = [
         {
             "Header": ["uuid", "name", "state", "id", "vnc_port", "tags", "pid"],
             "Tabular": [
@@ -189,7 +189,7 @@ def test_mm_vms() -> None:
         }
     ]
 
-    result = api.mm_vms()
+    result = mock_mm_api.mm_vms()
     assert result["vm1"]["uuid"] == "uuid1"
     assert result["vm1"]["vnc"] == "5900"
     assert result["vm1"]["image"] == "img"
@@ -210,18 +210,15 @@ def test_parse_table() -> None:
     assert minimegaAPI._parse_table(table) == [{"h1": "v1", "h2": "v2"}]
 
 
-def test_cmd_to_dict() -> None:
+def test_cmd_to_dict(mock_mm_api) -> None:
     """Verify command helper composes parsing helpers."""
-    api = _build_api_without_init()
-    api._run_cmd = Mock(return_value=b"a|b\n1|2\n")
-    result = api._cmd_to_dict(["vm", "info"])
+    mock_mm_api._run_cmd = Mock(return_value=b"a|b\n1|2\n")
+    result = mock_mm_api._cmd_to_dict(["vm", "info"])
     assert result == [{"a": "1", "b": "2"}]
 
 
-def test_run_cmd(monkeypatch) -> None:
+def test_run_cmd(config, monkeypatch) -> None:
     """Verify raw command execution invokes minimega binary."""
-    from firewheel.config import config
-
     monkeypatch.setitem(config["minimega"], "install_dir", "/opt/minimega")
     mocked = Mock()
     mocked.stdout = b""
@@ -238,10 +235,9 @@ def test_run_cmd(monkeypatch) -> None:
     )
 
 
-def test_parse_host() -> None:
+def test_parse_host(mock_mm_api) -> None:
     """Verify host rows are converted to typed host dictionaries."""
-    api = _build_api_without_init()
-    host = api._parse_host(
+    host = mock_mm_api._parse_host(
         (
             "host1",
             [
@@ -264,10 +260,9 @@ def test_parse_host() -> None:
     }
 
 
-def test_get_hosts_all() -> None:
+def test_get_hosts_all(mock_mm_api) -> None:
     """Verify host list retrieval parses all hosts."""
-    api = _build_api_without_init()
-    api.mm.host.return_value = [
+    mock_mm_api.mm.host.return_value = [
         {
             "Header": ["cpus", "cpucommit", "memtotal", "memcommit"],
             "Tabular": [["8", "4", "1024", "512"]],
@@ -275,29 +270,29 @@ def test_get_hosts_all() -> None:
         }
     ]
 
-    hosts = api.get_hosts()
+    hosts = mock_mm_api.get_hosts()
     assert "host1" in hosts
     assert hosts["host1"]["cpus"] == 8
 
 
-def test_get_hosts_single_missing() -> None:
+def test_get_hosts_single_missing(mock_mm_api) -> None:
     """Verify specific host lookup returns None when absent."""
-    api = _build_api_without_init()
-    api.mm.host.return_value = []
-    assert api.get_hosts(host_key="missing") is None
+    mock_mm_api.mm.host.return_value = []
+    assert mock_mm_api.get_hosts(host_key="missing") is None
 
 
-def test_get_cpu_commit_ratio() -> None:
+def test_get_cpu_commit_ratio(mock_mm_api) -> None:
     """Verify CPU commit ratio is computed from current host info."""
-    api = _build_api_without_init()
-    with patch.object(api, "get_hosts", return_value={"cpus": 8, "cpucommit": 4}):
-        assert api.get_cpu_commit_ratio() == 0.5
+    with patch.object(
+        mock_mm_api,
+        "get_hosts",
+        return_value={"cpus": 8, "cpucommit": 4},
+    ):
+        assert mock_mm_api.get_cpu_commit_ratio() == 0.5
 
 
-def test_init_raises_when_socket_missing(monkeypatch) -> None:
+def test_init_raises_when_socket_missing(config, monkeypatch) -> None:
     """Verify constructor raises when minimega socket is absent."""
-    from firewheel.config import config
-
     monkeypatch.setitem(config["minimega"], "base_dir", "/tmp/mm")
     monkeypatch.setitem(config["minimega"], "namespace", None)
     monkeypatch.setitem(config["cluster"], "control", ["headnode"])
@@ -307,10 +302,8 @@ def test_init_raises_when_socket_missing(monkeypatch) -> None:
             minimegaAPI()
 
 
-def test_init_raises_on_minimega_connection_failure(monkeypatch) -> None:
+def test_init_raises_on_minimega_connection_failure(config, monkeypatch) -> None:
     """Verify constructor wraps connection failures as RuntimeError."""
-    from firewheel.config import config
-
     monkeypatch.setitem(config["minimega"], "base_dir", "/tmp/mm")
     monkeypatch.setitem(config["minimega"], "namespace", None)
     monkeypatch.setitem(config["cluster"], "control", ["headnode"])
@@ -326,10 +319,8 @@ def test_init_raises_on_minimega_connection_failure(monkeypatch) -> None:
             minimegaAPI()
 
 
-def test_init_raises_timeout_from_check_version(monkeypatch) -> None:
+def test_init_raises_timeout_from_check_version(config, monkeypatch) -> None:
     """Verify constructor propagates TimeoutError from version check."""
-    from firewheel.config import config
-
     monkeypatch.setitem(config["minimega"], "base_dir", "/tmp/mm")
     monkeypatch.setitem(config["minimega"], "namespace", None)
     monkeypatch.setitem(config["cluster"], "control", ["headnode"])
@@ -353,16 +344,14 @@ def test_mmr_map_ignores_empty_tabular() -> None:
     assert minimegaAPI.mmr_map(raw) == {}
 
 
-def test_parse_host_none_returns_none() -> None:
+def test_parse_host_none_returns_none(mock_mm_api) -> None:
     """Verify parsing a falsey host item returns None."""
-    api = _build_api_without_init()
-    assert api._parse_host(None) is None
+    assert mock_mm_api._parse_host(None) is None
 
 
-def test_get_hosts_single_hit() -> None:
+def test_get_hosts_single_hit(mock_mm_api) -> None:
     """Verify specific host lookup returns parsed host."""
-    api = _build_api_without_init()
-    api.mm.host.return_value = [
+    mock_mm_api.mm.host.return_value = [
         {
             "Header": ["cpus", "cpucommit", "memtotal", "memcommit"],
             "Tabular": [["8", "4", "1024", "512"]],
@@ -370,19 +359,16 @@ def test_get_hosts_single_hit() -> None:
         }
     ]
 
-    host = api.get_hosts(host_key="host1")
+    host = mock_mm_api.get_hosts(host_key="host1")
     assert host["hostname"] == "host1"
     assert host["cpus"] == 8
 
 
 def test_run_minimega_script_raises_calledprocesserror(
-    monkeypatch, tmp_path: Path
+    config, monkeypatch, tmp_path: Path, mock_mm_api
 ) -> None:
     """Verify subprocess failures are re-raised by run_minimega_script."""
-    from firewheel.config import config
-
     monkeypatch.setitem(config["minimega"], "install_dir", "/opt/minimega")
-    api = _build_api_without_init()
 
     script = tmp_path / "launch.mm"
     script.write_text("vm info", encoding="utf-8")
@@ -392,15 +378,14 @@ def test_run_minimega_script_raises_calledprocesserror(
         side_effect=subprocess.CalledProcessError(1, ["minimega"]),
     ):
         with pytest.raises(subprocess.CalledProcessError):
-            api.run_minimega_script(script)
+            mock_mm_api.run_minimega_script(script)
 
 
-def test_run_minimega_script_raises_oserror(monkeypatch, tmp_path: Path) -> None:
+def test_run_minimega_script_raises_oserror(
+    config, monkeypatch, tmp_path: Path, mock_mm_api
+) -> None:
     """Verify launch failures are re-raised by run_minimega_script."""
-    from firewheel.config import config
-
     monkeypatch.setitem(config["minimega"], "install_dir", "/opt/minimega")
-    api = _build_api_without_init()
 
     script = tmp_path / "launch.mm"
     script.write_text("vm info", encoding="utf-8")
@@ -410,7 +395,7 @@ def test_run_minimega_script_raises_oserror(monkeypatch, tmp_path: Path) -> None
         side_effect=OSError("cannot launch"),
     ):
         with pytest.raises(OSError):
-            api.run_minimega_script(script)
+            mock_mm_api.run_minimega_script(script)
 
 
 def test_mmr_map_first_value_only_empty_returns_empty_dict() -> None:
@@ -432,19 +417,17 @@ def test_mmr_map_missing_header_key_raises() -> None:
         minimegaAPI.mmr_map(raw)
 
 
-def test_get_mesh_size_bad_shape_raises_keyerror() -> None:
+def test_get_mesh_size_bad_shape_raises_keyerror(mock_mm_api) -> None:
     """Verify malformed mesh_status output raises on missing expected keys."""
-    api = _build_api_without_init()
-    api.mm.mesh_status.return_value = [{"Tabular": []}]
+    mock_mm_api.mm.mesh_status.return_value = [{"Tabular": []}]
 
     with pytest.raises(KeyError):
-        api.get_mesh_size()
+        mock_mm_api.get_mesh_size()
 
 
-def test_mm_vms_bad_tags_json_raises() -> None:
+def test_mm_vms_bad_tags_json_raises(mock_mm_api) -> None:
     """Verify malformed VM tag JSON propagates."""
-    api = _build_api_without_init()
-    api.mm.vm_info.return_value = [
+    mock_mm_api.mm.vm_info.return_value = [
         {
             "Header": ["uuid", "name", "state", "id", "vnc_port", "tags", "pid"],
             "Tabular": [["uuid1", "vm1", "running", "1", "5900", "{bad json", "123"]],
@@ -453,7 +436,7 @@ def test_mm_vms_bad_tags_json_raises() -> None:
     ]
 
     with pytest.raises(Exception):
-        api.mm_vms()
+        mock_mm_api.mm_vms()
 
 
 def test_parse_table_with_only_header_returns_empty() -> None:


### PR DESCRIPTION
In relation to sandialabs/firewheel#289, this refactors unit-test setup into reusable pytest fixtures.